### PR TITLE
add caching of generated tts files

### DIFF
--- a/app/Console/Commands/CleanTTSCache.php
+++ b/app/Console/Commands/CleanTTSCache.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Storage;
+
+class CleanTTSCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:tts-clean {--days=7 : The number of days to keep cache files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove old TTS cache files from storage';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $days = $this->option('days');
+        $cutoffDate = now()->subDays($days);
+        $count = 0;
+
+        foreach (Storage::files('tts') as $file) {
+            $lastModified = Storage::lastModified($file);
+
+            if ($lastModified < $cutoffDate->timestamp) {
+                Storage::delete($file);
+                $count++;
+            }
+        }
+
+        $this->info("Deleted {$count} TTS cache files older than {$days} days ({$cutoffDate->toDateString()})");
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();
+// Artisan::command('inspire', function () {
+//     $this->comment(Inspiring::quote());
+// })->purpose('Display an inspiring quote')->hourly();
+
+Schedule::command('app:tts-clean --days=14')->daily();


### PR DESCRIPTION
- This caches text to speech audio content from azure service. Text, language, and voice is used as a key.
- Adds a command to clean TTS cache: `php artisan app:tts-clean --days=14`, which will remove any files older than 14 days.
- Registers the command to run nightly (if we're running laravel's scheduler as a cron).

Not sure if the timing is quite right.