### PR TITLE
update and simplify card import

### DIFF
--- a/app/Imports/CardsImport.php
+++ b/app/Imports/CardsImport.php
@@ -5,6 +5,7 @@ namespace App\Imports;
 use App\Models\Card;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Str;
 
 class CardsImport implements ToModel, WithHeadingRow
 {
@@ -15,6 +16,16 @@ class CardsImport implements ToModel, WithHeadingRow
         $this->deckId = $deckId;
     }
 
+    protected function createBlock(string $content, string $type = 'text')
+    {
+        return [
+            'id' => Str::uuid()->toString(),
+            'type' => $type,
+            'content' => $content,
+            'meta' => null,
+        ];
+    }
+
     /**
      * @return \Illuminate\Database\Eloquent\Model|null
      */
@@ -23,33 +34,17 @@ class CardsImport implements ToModel, WithHeadingRow
 
         return new Card([
             'deck_id' => $this->deckId,
-            'front' => [
-                'type' => $row['front_type'],
-                'content' => $row['front_content'],
-                'meta' => isset($row['front_alt']) && $row['front_alt']
-                ? ['alt' => $row['front_alt']]
-                : null,
-            ],
-            'back' => [
-                'type' => $row['back_type'],
-                'content' => $row['back_content'],
-                'meta' => isset($row['back_alt']) && $row['back_alt']
-                ? ['alt' => $row['back_alt']]
-                : null,
-            ],
+            //create a single block for each side of the card
+            'front' => [$this->createBlock($row['front'])],
+            'back' => [$this->createBlock($row['back'])],
         ]);
     }
 
     public function rules(): array
     {
         return [
-            'front_type' => 'required|string',
-            'front_content' => 'required|string',
-            'front_alt' => 'sometimes|nullable|string',
-
-            'back_type' => 'required|string',
-            'back_content' => 'required|string',
-            'back_alt' => 'sometimes|nullable|string',
+            'front' => 'required|string',
+            'back' => 'required|string',
         ];
     }
 }

--- a/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
@@ -21,7 +21,7 @@
           Practice
         </RouterLink>
       </DropdownMenuItem>
-      <!-- <DropdownMenuItem asChild v-if="deck.capabilities.canUpdate">
+      <DropdownMenuItem asChild v-if="deck.capabilities.canUpdate">
         <RouterLink
           :to="{ name: 'decks.import', params: { deckId: deck.id } }"
           class="btn"
@@ -30,7 +30,7 @@
           <IconUpload class="size-5 mr-4" />
           Import Cards
         </RouterLink>
-      </DropdownMenuItem> -->
+      </DropdownMenuItem>
       <DropdownMenuItem
         v-if="deck.capabilities.canLeave"
         @click="handleLeaveDeck(deck.id)"

--- a/resources/client/pages/Decks/ImportDeckCardsPage.vue
+++ b/resources/client/pages/Decks/ImportDeckCardsPage.vue
@@ -17,46 +17,29 @@
       <main>
         <section class="my-8">
           <p>
-            Import cards into the <b>{{ deck.name }}</b> deck from a CSV file in
-            the following format:
+            Import text cards into the <b>{{ deck.name }}</b> deck from a CSV
+            file in the following format:
           </p>
 
           <div class="font-mono border my-4 rounded-lg p-4">
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead class="w-[100px]">front_type</TableHead>
-                  <TableHead>front_content</TableHead>
-                  <TableHead>front_alt</TableHead>
-                  <TableHead>back_type</TableHead>
-                  <TableHead>back_content</TableHead>
-                  <TableHead>back_alt</TableHead>
+                  <TableHead>front</TableHead>
+                  <TableHead>back</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 <TableRow>
-                  <TableCell>image</TableCell>
-                  <TableCell>https://...</TableCell>
-                  <TableCell>Map of MN</TableCell>
-                  <TableCell>text</TableCell>
-                  <TableCell>Minnesota</TableCell>
-                  <TableCell></TableCell>
+                  <TableCell>Bonjour</TableCell>
+                  <TableCell>Hello</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Comment ça va?</TableCell>
+                  <TableCell>How are you?</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
-          </div>
-
-          <div
-            class="bg-blue-50 border border-blue-100 p-4 rounded-lg text-xs text-blue-800 flex gap-4 items-center"
-          >
-            <div class="bg-blue-100 p-2 rounded-full">
-              <IconExclamationTriangle />
-            </div>
-            <p>
-              Supported <code>front_type</code> and <code>back_type</code>:
-              <code>text</code>, <code>image</code>, <code>audio</code>,
-              <code>embed</code>
-            </p>
           </div>
         </section>
 
@@ -70,6 +53,7 @@
             type="file"
             ref="fileInput"
             class="p-4 h-auto my-2 border border-dashed border-black/50 rounded-lg"
+            @change="handleFileInputChange"
           />
           <Button
             type="submit"
@@ -110,12 +94,20 @@ const props = defineProps<{
 }>();
 
 const fileInput = ref<HTMLInputElement | null>(null);
-// const selectedFile = ref<File | null>(null);
-const selectedFile = computed(() => fileInput.value?.files?.[0] || null);
+const selectedFile = ref<File | null>(null);
 const deckIdRef = computed(() => props.deckId);
 const { data: deck } = useDeckByIdQuery(deckIdRef);
 
 const router = useRouter();
+
+function handleFileInputChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (!target.files) {
+    return;
+  }
+
+  selectedFile.value = target.files[0];
+}
 
 async function handleImport() {
   if (!selectedFile.value) {


### PR DESCRIPTION
This lets users import text cards.

Previously, there was hidden functionality to import a variety of card types: "image" card, "text" card, etc. However, the structure of cards changed to use blocks so that cards could support multiple content types within the same card. 

Creating a CSV to permit multiple block types within the same card would be too complicated for most users (it's probably easier to use the card editor rather than trying to construct the CSV). So, this changes import to the most common use case: text cards. 

"Import Cards" is added as an option to the &vellip; dropdown for a Deck.

On dev for testing.
