### PR TITLE
fix: content shifts when dropdown is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@headlessui/vue": "^1.7.22",
         "@radix-icons/vue": "^1.0.0",
         "@tanstack/vue-query": "^5.45.0",
-        "@umn-latis/cla-vue-template": "^1.2.0",
+        "@umn-latis/cla-vue-template": "^1.2.2",
         "@vueuse/core": "^10.11.0",
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.0",
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/@umn-latis/cla-vue-template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@umn-latis/cla-vue-template/-/cla-vue-template-1.2.0.tgz",
-      "integrity": "sha512-L6M9KwYxHIE3Vb5azcxmrQFwUjm14QXq20UQQAV46df7H3bGR+tn+Dsyk+EFoAcii0fNFv1q7YnH8dPHKurlLg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@umn-latis/cla-vue-template/-/cla-vue-template-1.2.2.tgz",
+      "integrity": "sha512-dyIYGfs4tTx0EHH4fD6RTsmMQHxqB0RjMVDqSQKY6MMGoq5YG9jvbLXNESQAsNv8lx4Q5Iq+jnZebW9/7Pj8HQ==",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@headlessui/vue": "^1.7.22",
     "@radix-icons/vue": "^1.0.0",
     "@tanstack/vue-query": "^5.45.0",
-    "@umn-latis/cla-vue-template": "^1.2.0",
+    "@umn-latis/cla-vue-template": "^1.2.2",
     "@vueuse/core": "^10.11.0",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
Issue was `!important` in cla-vue-template, which is resolved in v1.2.2

Fixes #86

Before - content shifts when dropdown is opened
After - no content shift

|BEFORE | AFTER |
|--|--|
|<img width="400" src="https://github.com/user-attachments/assets/cfd1be29-0a9d-4c22-808b-4c8a904e42d5" alt="before - content shifts"/>|<img width="400" src="https://github.com/user-attachments/assets/6ac780fc-8aec-4791-a036-ccc716434aa9" alt="after - content doesn't shift"/>|
