### PR TITLE
improve a11y for card block inputs

### DIFF
--- a/resources/client/components/BlockEditor/AudioBlockInput.vue
+++ b/resources/client/components/BlockEditor/AudioBlockInput.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="p-2">
     <div v-if="!modelValue">
-      <Label class="sr-only">Audio</Label>
+      <Label class="sr-only" :for="makeInputId('audio-drop')">Audio</Label>
       <FilePond
+        :id="makeInputId('audio-drop')"
         name="audio"
         ref="pond"
         labelIdle="Add audio file (.mp3, .ogg, .m4a, .aac, .midi)"
@@ -14,8 +15,9 @@
       />
       <p class="text-neutral-400 text-xs text-center">— or —</p>
       <div>
-        <Label class="sr-only" for="image-url">Audio Url</Label>
+        <Label class="sr-only" :for="makeInputId('audio-url')">Audio Url</Label>
         <Input
+          :id="makeInputId('audio-url')"
           :modelValue="modelValue"
           @update:modelValue="$emit('update:modelValue', $event as string)"
           placeholder="Audio URL"
@@ -43,6 +45,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import * as api from "@/api";
+import { ContentBlock } from "@/types";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import vueFilePond from "vue-filepond";
@@ -51,8 +54,10 @@ import { IconX } from "../icons";
 
 import "filepond/dist/filepond.min.css";
 import "filepond-plugin-image-preview/dist/filepond-plugin-image-preview.min.css";
+import { useMakeInputId } from "@/composables/useMakeInputId";
 
-defineProps<{
+const props = defineProps<{
+  id: ContentBlock["id"];
   modelValue: string;
 }>();
 
@@ -60,6 +65,7 @@ const emit = defineEmits<{
   (event: "update:modelValue", value: string): void;
 }>();
 
+const { makeInputId } = useMakeInputId("audio-block-input", props.id);
 const FilePond = vueFilePond(FilePondPluginFileValidateType);
 
 const myFiles = ref<string[]>([]);

--- a/resources/client/components/BlockEditor/BlockEditor.vue
+++ b/resources/client/components/BlockEditor/BlockEditor.vue
@@ -7,7 +7,10 @@
       handle=".drag-handle"
     >
       <template #item="{ element: block }">
-        <div class="flex border-b border-black/5">
+        <div
+          class="flex border-b border-black/5"
+          data-cy="content-block-container"
+        >
           <button class="drag-handle cursor-move flex items-start px-1 py-3">
             <Icons.IconDragHandle class="size-4" />
             <span class="sr-only">Drag to reorder</span>
@@ -20,6 +23,7 @@
               <button
                 class="cursor-pointer flex items-start px-3 py-3"
                 @click="removeBlock(block.id)"
+                data-cy="remove-content-block-button"
               >
                 <Icons.IconX class="size-4" />
                 <span class="sr-only">Remove block</span>
@@ -27,6 +31,7 @@
             </div>
             <div class="pr-3 pb-3">
               <component
+                :id="block.id"
                 :is="getComponentForType(block.type)"
                 :modelValue="block.content"
                 @update:modelValue="handleUpdateBlockContent(block.id, $event)"

--- a/resources/client/components/BlockEditor/EmbedBlockInput.vue
+++ b/resources/client/components/BlockEditor/EmbedBlockInput.vue
@@ -16,7 +16,7 @@
       Invalid URL
     </div>
     <InputGroup
-      :id="`embedUrl`"
+      :id="makeInputId('embed-url')"
       label="Embed Url"
       :labelHidden="true"
       required
@@ -32,15 +32,19 @@
 import { computed } from "vue";
 import { isValidUrl } from "@/lib/utils";
 import InputGroup from "@/components/InputGroup.vue";
-import EmbedVideo from "@/components/EmbedVideo.vue";
+import { ContentBlock } from "@/types";
+import { useMakeInputId } from "@/composables/useMakeInputId";
 
 const props = defineProps<{
+  id: ContentBlock["id"];
   modelValue: string;
 }>();
 
 const emit = defineEmits<{
   (event: "update:modelValue", value: string): void;
 }>();
+
+const { makeInputId } = useMakeInputId("embed-block-input", props.id);
 
 const isValidUrlComputed = computed(() => isValidUrl(props.modelValue));
 </script>

--- a/resources/client/components/BlockEditor/HintBlockInput.vue
+++ b/resources/client/components/BlockEditor/HintBlockInput.vue
@@ -1,23 +1,24 @@
 <template>
-  <div :id="`hint-block-${id}`">
-    <Label :for="`hint-block-${id}__text`" class="sr-only">Hint</Label>
+  <div data-cy="hint-block-input">
+    <Label :for="makeInputId('hidden-text')" class="sr-only">Hint</Label>
     <InputGroup
-      :id="`hint-block-${id}__text`"
+      :id="makeInputId('hidden-text')"
       label="Hidden Text"
       :labelHidden="true"
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
-      placeholder="Hidden content"
+      placeholder="Hint text"
     />
   </div>
 </template>
 <script setup lang="ts">
 import { Label } from "@/components/ui/label";
 import InputGroup from "@/components/InputGroup.vue";
+import { useMakeInputId } from "@/composables/useMakeInputId";
+import { ContentBlock } from "@/types";
 
-const id = crypto.randomUUID();
-
-defineProps<{
+const props = defineProps<{
+  id: ContentBlock["id"];
   modelValue: string; // hidden content
   meta: {
     label: string; // e.g. "Hint"
@@ -28,5 +29,7 @@ defineEmits<{
   (event: "update:modelValue", value: string): void;
   (event: "update:meta", value: { label: string }): void;
 }>();
+
+const { makeInputId } = useMakeInputId("hint-block-input", props.id);
 </script>
 <style scoped></style>

--- a/resources/client/components/BlockEditor/ImageBlockInput.vue
+++ b/resources/client/components/BlockEditor/ImageBlockInput.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="p-2">
+  <div class="p-2" data-cy="image-block-input">
     <div v-if="!modelValue">
-      <Label class="sr-only">Image</Label>
+      <Label class="sr-only" :for="makeInputId('image-drop')">Image</Label>
       <FilePond
+        :id="makeInputId('image-drop')"
         name="image"
         ref="pond"
         labelIdle="Add an image"
@@ -36,8 +37,9 @@
     </div>
     <p class="text-neutral-400 text-xs text-center mt-4">— or —</p>
     <div class="mb-2">
-      <Label for="image-url" class="sr-only">Image Url</Label>
+      <Label :for="makeInputId('image-url')" class="sr-only">Image Url</Label>
       <Input
+        :id="makeInputId('image-url')"
         :modelValue="modelValue"
         @update:modelValue="$emit('update:modelValue', $event as string)"
         placeholder="Image URL"
@@ -45,8 +47,9 @@
       />
     </div>
     <div>
-      <Label class="sr-only">Alt Text</Label>
+      <Label class="sr-only" :for="makeInputId('alt-text')">Alt Text</Label>
       <Input
+        :id="makeInputId('alt-text')"
         :modelValue="meta.alt"
         @update:modelValue="
           $emit('update:meta', { ...meta, alt: $event as string })
@@ -65,12 +68,14 @@ import { Input } from "@/components/ui/input";
 import vueFilePond from "vue-filepond";
 import FilePondPluginFileValidateType from "filepond-plugin-file-validate-type";
 import { IconX } from "../icons";
-
 import "filepond/dist/filepond.min.css";
 import "filepond-plugin-image-preview/dist/filepond-plugin-image-preview.min.css";
 import { isValidUrl } from "@/lib/utils";
+import * as T from "@/types";
+import { useMakeInputId } from "@/composables/useMakeInputId";
 
 const props = defineProps<{
+  id: T.ContentBlock["id"];
   modelValue: string;
   meta: {
     alt: string;
@@ -81,6 +86,8 @@ const emit = defineEmits<{
   (event: "update:modelValue", value: string): void;
   (event: "update:meta", value: { alt: string }): void;
 }>();
+
+const { makeInputId } = useMakeInputId("image-block-input", props.id);
 
 const FilePond = vueFilePond(FilePondPluginFileValidateType);
 const isValidUrlComputed = computed(() => isValidUrl(props.modelValue));

--- a/resources/client/components/BlockEditor/MathBlockInput.vue
+++ b/resources/client/components/BlockEditor/MathBlockInput.vue
@@ -1,26 +1,33 @@
 <template>
   <div class="math-block-input">
+    <label :for="makeInputId('math-field')" class="sr-only"> Math Field</label>
     <VueMathField
-      id="test"
+      :id="makeInputId('math-field')"
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
     />
     <div class="mt-2">
-      <label class="text-xs flex justify-end gap-2">
+      <label
+        class="text-xs flex justify-end gap-2"
+        :for="makeInputId('show-latex')"
+      >
         Show LaTeX
         <input
+          :id="makeInputId('show-latex')"
           type="checkbox"
           v-model="isShowingLatex"
           class="bg-black/5 border-black/20 rounded-sm"
         />
       </label>
       <label
+        :for="makeInputId('latex-editor')"
         class="mt-1 block bg-black/5 rounded-sm focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-blue-600"
         v-if="isShowingLatex"
       >
         <span class="text-xs text-brand-maroon-900/50 px-2">LaTeX Editor</span>
         <code>
           <textarea
+            :id="makeInputId('latex-editor')"
             class="block break-all w-full bg-transparent border-none focus:ring-0 px-2 py-0 text-sm"
             :value="modelValue"
             @input="
@@ -38,9 +45,11 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import VueMathField from "@/components/VueMathField.vue";
-import { MathContentBlock } from "../../types";
+import { MathContentBlock } from "@/types";
+import { useMakeInputId } from "@/composables/useMakeInputId";
 
-defineProps<{
+const props = defineProps<{
+  id: MathContentBlock["id"];
   modelValue: MathContentBlock["content"];
 }>();
 
@@ -48,6 +57,7 @@ defineEmits<{
   (event: "update:modelValue", value: MathContentBlock["content"]): void;
 }>();
 
+const { makeInputId } = useMakeInputId("math-block-input", props.id);
 const isShowingLatex = ref(false);
 </script>
 <style scoped></style>

--- a/resources/client/components/BlockEditor/VideoBlockInput.vue
+++ b/resources/client/components/BlockEditor/VideoBlockInput.vue
@@ -12,7 +12,7 @@
       Invalid URL
     </div>
     <InputGroup
-      :id="`embedUrl`"
+      :id="makeInputId('video-block')"
       label="YouTube"
       :labelHidden="true"
       required
@@ -29,6 +29,7 @@ import { computed } from "vue";
 import { isValidUrl } from "@/lib/utils";
 import InputGroup from "@/components/InputGroup.vue";
 import EmbedVideo from "@/components/EmbedVideo.vue";
+import { useMakeInputId } from "@/composables/useMakeInputId";
 
 const props = defineProps<{
   modelValue: string;
@@ -39,5 +40,6 @@ const emit = defineEmits<{
 }>();
 
 const isValidUrlComputed = computed(() => isValidUrl(props.modelValue));
+const { makeInputId } = useMakeInputId("video-block-input");
 </script>
 <style scoped></style>

--- a/resources/client/components/Toggle.vue
+++ b/resources/client/components/Toggle.vue
@@ -11,6 +11,7 @@
         props.class,
       )
     "
+    :aria-pressed="modelValue"
     :aria-label="label"
     :title="label"
   >

--- a/resources/client/composables/useMakeInputId.ts
+++ b/resources/client/composables/useMakeInputId.ts
@@ -1,0 +1,19 @@
+/**
+ * a helper to generate consistent ids for inputs/labels
+ * without a lot of boilerplate
+ * @example
+ * const { makeInputId } = useMakeInputId('image-block-editor');
+ * <input :id="makeInputId('alt-text')" />
+ */
+export const useMakeInputId = (
+  componentName: string,
+  componentId?: string | number,
+) => {
+  // generate a random uuid if needed
+  componentId ??= crypto.randomUUID();
+
+  const makeInputId = (inputName: string) =>
+    `${componentName}__${inputName}__${componentId}`;
+
+  return { makeInputId };
+};


### PR DESCRIPTION
This fixes a few accessibility issues:

- adds corresponding ids to all inputs and labels
- fixes issue where ids may not be unique if multiple blocks of same type can appear on page
- adds `aria-pressed` to Toggle to indicate state
- adds `role="textbox"` to quill's `contenteditable` div.
- adds a helper for making consistent input ids.