### PR TITLE
fix: deck search filtering cards without text

### DIFF
--- a/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
+++ b/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
@@ -203,6 +203,8 @@ function doesBlockContainText(block: T.ContentBlock, text: string) {
 const filteredCards = computed((): T.Card[] => {
   if (!deck.value?.cards) return [];
 
+  if (!cardSearch.value) return deck.value.cards;
+
   return deck.value.cards.filter((card) => {
     return [...card.front, ...card.back].some((block) => {
       return doesBlockContainText(block, cardSearch.value);


### PR DESCRIPTION
Fixes an issue where non-text cards would be hidden if search was empty