### PR TITLE
fix: url input is hidden after first keystroke

### DIFF
--- a/resources/client/components/BlockEditor/AudioBlockInput.vue
+++ b/resources/client/components/BlockEditor/AudioBlockInput.vue
@@ -13,37 +13,47 @@
         }"
         :files="myFiles"
       />
-      <p class="text-neutral-400 text-xs text-center">— or —</p>
-      <div>
-        <Label class="sr-only" :for="makeInputId('audio-url')">Audio Url</Label>
-        <Input
-          :id="makeInputId('audio-url')"
-          :modelValue="modelValue"
-          @update:modelValue="$emit('update:modelValue', $event as string)"
-          placeholder="Audio URL"
-          class="bg-brand-maroon-800/5"
-        />
-      </div>
     </div>
-    <div v-else class="flex items-center justify-center">
-      <div class="relative pt-2 pr-2">
-        <audio controls :src="modelValue" class="block border-4 rounded-lg">
-          Your browser does not support the
-          <code>audio</code> element.
-        </audio>
-        <button
-          class="absolute top-0 right-0 bg-neutral-700 hover:bg-brand-maroon-800 text-neutral-100 rounded-full w-6 h-6 flex items-center justify-center transition-colors"
-          @click="$emit('update:modelValue', '')"
-        >
-          <IconX />
-          <span class="sr-only">Clear</span>
-        </button>
+
+    <div v-else class="relative pt-2 pr-2">
+      <audio
+        v-if="isValidUrlComputed"
+        controls
+        :src="modelValue"
+        class="block border-4 rounded-lg"
+      >
+        Your browser does not support the
+        <code>audio</code> element.
+      </audio>
+      <div
+        v-else
+        class="h-12 flex items-center justify-center bg-brand-maroon-800/5 rounded-lg"
+      >
+        <p class="text-neutral-400 text-sm">Invalid audio URL</p>
       </div>
+      <button
+        class="absolute top-0 right-0 bg-neutral-700 hover:bg-brand-maroon-800 text-neutral-100 rounded-full w-6 h-6 flex items-center justify-center transition-colors"
+        @click="$emit('update:modelValue', '')"
+      >
+        <IconX />
+        <span class="sr-only">Clear</span>
+      </button>
+    </div>
+    <p class="text-neutral-400 text-xs text-center mt-4">— or —</p>
+    <div class="mb-2">
+      <Label :for="makeInputId('image-url')" class="sr-only">Image Url</Label>
+      <Input
+        :id="makeInputId('image-url')"
+        :modelValue="modelValue"
+        @update:modelValue="$emit('update:modelValue', $event as string)"
+        placeholder="Image URL"
+        class="bg-brand-maroon-800/5"
+      />
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import * as api from "@/api";
 import { ContentBlock } from "@/types";
 import { Label } from "@/components/ui/label";
@@ -51,6 +61,7 @@ import { Input } from "@/components/ui/input";
 import vueFilePond from "vue-filepond";
 import FilePondPluginFileValidateType from "filepond-plugin-file-validate-type";
 import { IconX } from "../icons";
+import { isValidUrl } from "@/lib/utils";
 
 import "filepond/dist/filepond.min.css";
 import "filepond-plugin-image-preview/dist/filepond-plugin-image-preview.min.css";
@@ -69,6 +80,7 @@ const { makeInputId } = useMakeInputId("audio-block-input", props.id);
 const FilePond = vueFilePond(FilePondPluginFileValidateType);
 
 const myFiles = ref<string[]>([]);
+const isValidUrlComputed = computed(() => isValidUrl(props.modelValue));
 
 function onFileChange(file: File) {
   return api.uploadFile(file);
@@ -77,11 +89,11 @@ function onFileChange(file: File) {
 async function handleProcessImage(
   _fieldName: string,
   file: File,
-  _metadata: any,
-  load: any,
-  _error: any,
-  _progress: any,
-  abort: any,
+  _metadata: unknown,
+  load: (url: string) => void,
+  _error: unknown,
+  _progress: unknown,
+  abort: unknown,
 ) {
   const fileInfo = await onFileChange(file);
 


### PR DESCRIPTION
fixes #104 

On the card edit/create page, the audio block will hide the input field once there's some text in it. This is fine if copy/pastes a url, but if they're typing a url for some reason the user won't be able to continue after first character. Additionally, whether the url is valid or not an audio player shows.

This changes the block to be similar to the image block:
- the url field is always visible
- invalid urls will show an error, not try rendering an audio component
