### PR TITLE
improve community page join flow

### DIFF
--- a/resources/client/pages/CommunityDecks/CommunityDeckShowPage.vue
+++ b/resources/client/pages/CommunityDecks/CommunityDeckShowPage.vue
@@ -19,7 +19,7 @@
             </Button>
             <Button
               v-if="deck.capabilities.canJoinAsViewer"
-              @click="joinDeck(deck.id)"
+              @click="handleJoinDeck"
               >Join</Button
             >
             <Button
@@ -54,6 +54,7 @@ import FlippableCard from "@/components/FlippableCard.vue";
 import { ref } from "vue";
 import { useJoinCommunityDeckMutation } from "@/queries/community";
 import { useLeaveDeckMutation } from "@/queries/deckMemberships";
+import { useRouter } from "vue-router";
 
 const props = defineProps<{
   deckId: number;
@@ -70,6 +71,12 @@ function flipAllCards() {
 }
 
 const { mutate: joinDeck } = useJoinCommunityDeckMutation();
+
+const router = useRouter();
+async function handleJoinDeck() {
+  await joinDeck(deckIdRef.value);
+  router.push({ name: "decks.show", params: { deckId: deckIdRef.value } });
+}
 const { mutate: leaveDeck } = useLeaveDeckMutation();
 </script>
 <style scoped></style>

--- a/resources/client/pages/CommunityDecks/CommunityDecksIndexPage.vue
+++ b/resources/client/pages/CommunityDecks/CommunityDecksIndexPage.vue
@@ -18,7 +18,26 @@
               <h3 class="text-lg font-bold">{{ deck.name }}</h3>
               <p class="text-sm text-stone-400 mb-4">{{ deck.description }}</p>
 
-              <div class="flex gap-2 justify-end">
+              <div v-if="deck.current_user_role" class="flex gap-2 justify-end">
+                <Button asChild variant="secondary">
+                  <RouterLink
+                    :to="{
+                      name: 'decks.show',
+                      params: { deckId: deck.id },
+                    }"
+                    class="btn btn-primary"
+                    >View</RouterLink
+                  >
+                </Button>
+                <Button
+                  v-if="deck.capabilities.canLeave"
+                  @click="leaveDeck(deck.id)"
+                  variant="destructive"
+                  >Leave</Button
+                >
+              </div>
+
+              <div v-else class="flex gap-2 justify-end">
                 <Button asChild variant="secondary">
                   <RouterLink
                     :to="{
@@ -33,12 +52,6 @@
                   v-if="deck.capabilities.canJoinAsViewer"
                   @click="joinDeck(deck.id)"
                   >Join</Button
-                >
-                <Button
-                  v-else-if="deck.capabilities.canLeave"
-                  @click="leaveDeck(deck.id)"
-                  variant="destructive"
-                  >Leave</Button
                 >
               </div>
             </article>


### PR DESCRIPTION
Previously, the "Preview" action on the community deck page was a little confusing. If you were already a member of the deck, you'd still see a "preview" button. Clicking on the button was bring you to the Preview page, and since preview and view deck pages look very similar, it wasn't obvious why some of the page functionality was different (missing "Practice" button).

Now:
- if the user is already a member of the deck, the community page now shows a "View" button instead of "Preview". 
- Clicking "View" will take the user to the deck show page, not the preview page, so they'll see full functionality.
- if the user is on the Preview page and chooses to "Join" a deck, they will be redirected to the deck show view.

on dev