### PR TITLE
Improve Quizzing with Math

### DIFF
--- a/app/Library/QuizMaker.php
+++ b/app/Library/QuizMaker.php
@@ -110,14 +110,14 @@ interface Quiz {
             ->map(fn ($card) => $this->normalizeCard($card));
     }
 
-    public function getPrompt($level = 'medium')
+    public function getPrompt($level = 'easy')
     {
         $stringifiedCards = $this->getNormalizedCards()->toJson();
         $numberOfQuestions = $this->options['numberOfQuestions'];
         $cardSide = $this->options['cardSide'];
 
         $prompts = [
-            'easy' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards. Use the {$cardSide} side of the card as the basis for a question prompt. Include only the required information in the prompt.",
+            'easy' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards. Use the {$cardSide} side of the card as the basis for a question prompt. Include only the required information in the prompt. If the question has mathematical content, the question should require the user to apply the mathematical concept to solve a problem and not use the exact same numbers.",
 
             'medium' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, but the quiz prompt and responses MUST NOT be a simple repetition of the flash card data. If the flash card data is a simple fact, the quiz question should require the user to apply, analyze, or synthesize the information to answer the question. If the question has mathematical content, the question should require the user to apply the mathematical concept to solve a problem and not use the exact same numbers.",
 

--- a/app/Library/QuizMaker.php
+++ b/app/Library/QuizMaker.php
@@ -118,10 +118,7 @@ interface Quiz {
 
         $prompts = [
             'easy' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards. Use the {$cardSide} side of the card as the basis for a question prompt. Include only the required information in the prompt. If the question has mathematical content, the question should require the user to apply the mathematical concept to solve a problem and not use the exact same numbers.",
-
-            'medium' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, but the quiz prompt and responses MUST NOT be a simple repetition of the flash card data. If the flash card data is a simple fact, the quiz question should require the user to apply, analyze, or synthesize the information to answer the question. If the question has mathematical content, the question should require the user to apply the mathematical concept to solve a problem and not use the exact same numbers.",
-
-            'hard' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, testing both front to back and back to front knowledge. The questions should be at a higher level of Bloom's Taxonomy, requiring application, analysis, or synthesis of multiple cards to answer.",
+            'medium' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, testing both front to back and back to front knowledge. The questions should be at a higher level of Bloom's Taxonomy, requiring application, analysis, or synthesis of multiple cards to answer.",
         ];
 
         $prompt = $prompts[$level];

--- a/app/Library/QuizMaker.php
+++ b/app/Library/QuizMaker.php
@@ -4,7 +4,6 @@ namespace App\Library;
 
 use App\Library\OpenAIService\OpenAIService;
 use App\Models\Deck;
-use Barryvdh\Debugbar\Facades\Debugbar;
 use Illuminate\Support\Collection;
 
 class QuizMaker
@@ -181,13 +180,6 @@ interface Quiz {
         $response = $this->removeMarkdownFences($response);
 
         $quiz = json_decode($response, true);
-
-        Debugbar::info([
-            'prompt' => $this->getPrompt(),
-            'systemText' => $this->getSystemText(),
-            'response' => $response,
-            'quiz' => $quiz,
-        ]);
 
         $sourceCardIds = collect($quiz['questions'])->map(fn ($question) => $question['sourceCardId']);
 

--- a/app/Library/QuizMaker.php
+++ b/app/Library/QuizMaker.php
@@ -31,7 +31,7 @@ class QuizMaker
     {
         $challengeLevel = $this->options['challenge_level'];
         $systemText =
-"You generate high quality multiple choice quizzes from a set of json flash card data at the {$challengeLevel} level. Include challenging distractors that are not part of the flash card data set. Your response should use the following formats and respond in JSON. Both the prompt and choices should be plain text only with no markup.".
+"You generate high quality multiple choice quizzes from a set of json flash card data at the {$challengeLevel} level. Include challenging distractors that are not part of the flash card data set. Your response should use the following formats and respond in JSON. The prompt and responses should be in proper markdown. Use proper markdown any math or LaTeX wrapping it with $, like $\\frac{1}{2}$.".
 
 "```ts
 interface Question {
@@ -65,7 +65,7 @@ interface Quiz {
 
         return collect($contentBlocks)
             ->map(function ($block) {
-                if ($block['type'] === 'text') {
+                if (collect(['text', 'math'])->contains($block['type'])) {
                     return $block['content'];
                 }
 
@@ -110,7 +110,7 @@ interface Quiz {
             ->map(fn ($card) => $this->normalizeCard($card));
     }
 
-    public function getPrompt($level = 'easy')
+    public function getPrompt($level = 'medium')
     {
         $stringifiedCards = $this->getNormalizedCards()->toJson();
         $numberOfQuestions = $this->options['numberOfQuestions'];
@@ -119,7 +119,9 @@ interface Quiz {
         $prompts = [
             'easy' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards. Use the {$cardSide} side of the card as the basis for a question prompt. Include only the required information in the prompt.",
 
-            'medium' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, testing both front to back and back to front knowledge. The questions should be at a higher level of Bloom's Taxonomy, requiring application, analysis, or synthesis of multiple cards to answer.",
+            'medium' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, but the quiz prompt and responses MUST NOT be a simple repetition of the flash card data. If the flash card data is a simple fact, the quiz question should require the user to apply, analyze, or synthesize the information to answer the question. If the question has mathematical content, the question should require the user to apply the mathematical concept to solve a problem and not use the exact same numbers.",
+
+            'hard' => "Generate a quiz of {$numberOfQuestions} questions from the following flash cards, testing both front to back and back to front knowledge. The questions should be at a higher level of Bloom's Taxonomy, requiring application, analysis, or synthesis of multiple cards to answer.",
         ];
 
         $prompt = $prompts[$level];

--- a/app/Library/QuizMaker.php
+++ b/app/Library/QuizMaker.php
@@ -32,7 +32,7 @@ class QuizMaker
     {
         $challengeLevel = $this->options['challenge_level'];
         $systemText =
-"You generate high quality multiple choice quizzes from a set of json flash card data at the {$challengeLevel} level. Include challenging distractors that are not part of the flash card data set. Your response should use the following formats and respond in JSON. The prompt and responses should be in proper markdown. Use proper markdown any math or LaTeX wrapping it with $, like $\\frac{1}{2}$.".
+"You generate high quality multiple choice quizzes from a set of json flash card data at the {$challengeLevel} level. Include challenging distractors that are not part of the flash card data set. Your response should use the following formats and respond in JSON. The prompt and choices should be in proper markdown. Whenever you output any math content (like \\frac{1}{2} or \\sqrt{2}), please always wrap it in $ for inline math. For example, output \\frac{1}{2} as $\\frac{1}{2}$.".
 
 "```ts
 interface Question {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
   {
     rules: {
       "@typescript-eslint/no-unused-vars": "warn",
+      "vue/multi-word-component-names": "off",
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "filepond-plugin-file-validate-type": "^1.2.9",
         "filepond-plugin-image-preview": "^4.6.12",
         "katex": "^0.16.21",
+        "marked": "^15.0.6",
+        "marked-katex-extension": "^5.1.4",
         "mathlive": "^0.103.0",
         "p-debounce": "^4.0.0",
         "pinia": "^2.3.0",
@@ -6143,6 +6145,28 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.6.tgz",
+      "integrity": "sha512-Y07CUOE+HQXbVDCGl3LXggqJDbXDP2pArc2C1N1RRMN0ONiShoSsIInMd5Gsxupe7fKLpgimTV+HOJ9r7bA+pg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-katex-extension": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.4.tgz",
+      "integrity": "sha512-GQOio4vCp0laxB1IY+2oNVo5nbn82yWMDP/jILRYHmyu2WXMVlXCB+krq2/U2fQn+V9j8aqDmnNdrsgqG2AkGQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "katex": ">=0.16 <0.17",
+        "marked": ">=4 <16"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "filepond-plugin-file-validate-type": "^1.2.9",
     "filepond-plugin-image-preview": "^4.6.12",
     "katex": "^0.16.21",
+    "marked": "^15.0.6",
+    "marked-katex-extension": "^5.1.4",
     "mathlive": "^0.103.0",
     "p-debounce": "^4.0.0",
     "pinia": "^2.3.0",

--- a/resources/client/components/CardSideView/CardSideView.vue
+++ b/resources/client/components/CardSideView/CardSideView.vue
@@ -25,7 +25,11 @@
           :modelValue="block.content"
           :meta="block.meta"
         />
-        <MathBlockView v-else-if="isMathBlock(block)" :block="block" />
+        <MathBlockView
+          v-else-if="isMathBlock(block)"
+          :block="block"
+          class="mx-auto"
+        />
         <UnknownBlockView v-else :block="block" />
       </template>
     </div>

--- a/resources/client/components/CardSideView/MathBlockView.vue
+++ b/resources/client/components/CardSideView/MathBlockView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="math-block-view flex justify-center">
+  <div class="math-block-view flex flex-wrap">
     <VueMathField
       :readOnly="true"
       :modelValue="block.content"

--- a/resources/client/components/Markdown.vue
+++ b/resources/client/components/Markdown.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-html="html" />
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import { marked } from "marked";
+import markedKatex from "marked-katex-extension";
+
+const props = defineProps<{
+  content: string;
+}>();
+
+const options = {
+  throwOnError: false,
+};
+
+marked.use(markedKatex(options));
+
+const html = computed(() => {
+  const html = marked.parse(props.content);
+  return html;
+});
+</script>
+<style scoped></style>

--- a/resources/client/components/Markdown.vue
+++ b/resources/client/components/Markdown.vue
@@ -3,22 +3,12 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { marked } from "marked";
-import markedKatex from "marked-katex-extension";
+import { markdownToHTML } from "@/lib/markdownToHTML";
 
 const props = defineProps<{
   content: string;
 }>();
 
-const options = {
-  throwOnError: false,
-};
-
-marked.use(markedKatex(options));
-
-const html = computed(() => {
-  const html = marked.parse(props.content);
-  return html;
-});
+const html = computed(() => markdownToHTML(props.content));
 </script>
 <style scoped></style>

--- a/resources/client/lib/markdownToHTML.ts
+++ b/resources/client/lib/markdownToHTML.ts
@@ -1,0 +1,15 @@
+import { marked, MarkedOptions } from "marked";
+import markedKatex, { MarkedKatexOptions } from "marked-katex-extension";
+
+const options: MarkedOptions & MarkedKatexOptions = {
+  throwOnError: false,
+  async: false,
+};
+
+marked.use(markedKatex(options));
+
+export function markdownToHTML(markdown: string): string {
+  // not using async so we can cast as string instead
+  // of Promise<string>
+  return marked.parse(markdown) as string;
+}

--- a/resources/client/pages/QuizDeckPage/Quiz.vue
+++ b/resources/client/pages/QuizDeckPage/Quiz.vue
@@ -21,22 +21,27 @@
         class="pl-4"
       >
         <div
-          class="flex items-center p-2"
+          class="flex items-center p-4 bg-brand-maroon-950/5 rounded-md transition"
           v-for="(choice, index) in activeQuestion.choices"
           :key="index"
           :class="{
-            'bg-brand-teal-300/10 rounded-md border border-brand-teal-500/50':
+            '!bg-brand-teal-300/10 rounded-md border border-brand-teal-500/50 !text-brand-teal-700':
               isChoiceMade && isChoiceIndexCorrect(index),
+            'hover:bg-brand-gold-500/50': !isChoiceMade,
           }"
         >
           <RadioGroupItem
             :id="getQuestionChoiceId(state.activeQuestionIndex, index)"
             :value="index.toString()"
             class="mr-2"
+            :class="{
+              'border-brand-teal-700':
+                isChoiceMade && isChoiceIndexCorrect(index),
+            }"
           />
           <Label
             :for="getQuestionChoiceId(state.activeQuestionIndex, index)"
-            class="flex w-full items-center justify-between gap-4"
+            class="flex w-full items-center justify-between gap-4 cursor-pointer"
           >
             <Markdown :content="choice" />
             <!-- <span>{{ choice }}</span> -->

--- a/resources/client/pages/QuizDeckPage/Quiz.vue
+++ b/resources/client/pages/QuizDeckPage/Quiz.vue
@@ -11,7 +11,8 @@
         :side="activeQuestionPromptMedia"
         class="mb-4"
       />
-      <p class="mb-4">{{ activeQuestion.prompt }}</p>
+      <!-- <p class="mb-4">{{ activeQuestion.prompt }}</p> -->
+      <Markdown :content="activeQuestion.prompt" class="mb-4" />
 
       <RadioGroup
         :modelValue="state.activeChoiceIndex?.toString()"
@@ -22,6 +23,7 @@
         <div
           class="flex items-center p-2"
           v-for="(choice, index) in activeQuestion.choices"
+          :key="index"
           :class="{
             'bg-brand-teal-300/10 rounded-md border border-brand-teal-500/50':
               isChoiceMade && isChoiceIndexCorrect(index),
@@ -36,7 +38,8 @@
             :for="getQuestionChoiceId(state.activeQuestionIndex, index)"
             class="flex w-full items-center justify-between gap-4"
           >
-            <span>{{ choice }}</span>
+            <Markdown :content="choice" />
+            <!-- <span>{{ choice }}</span> -->
             <span v-if="isChoiceMade && isChoiceIndexCorrect(index)">✅</span>
             <span v-else-if="isChoiceMade && state.activeChoiceIndex === index"
               >❌</span
@@ -83,6 +86,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Button } from "@/components/ui/button";
 import CardSideView from "@/components/CardSideView/CardSideView.vue";
+import Markdown from "@/components/Markdown.vue";
 
 const props = defineProps<{
   quiz: T.Quiz;
@@ -116,9 +120,11 @@ const activeQuestionPromptMedia = computed((): T.ContentBlock[] => {
   const card = activeQuestion.value.sourceCard;
   const side = activeQuestion.value.sourceCardSide;
   const contentBlocks = card[side];
-  const nonTextBlocks = contentBlocks.filter((block) => block.type !== "text");
+  const nonMarkdownableBlocks = contentBlocks.filter(
+    (block) => !["text", "math"].includes(block.type),
+  );
 
-  return nonTextBlocks;
+  return nonMarkdownableBlocks;
 });
 function isChoiceIndexCorrect(choiceIndex?: number): boolean {
   return activeQuestion.value.correctChoiceIndex === choiceIndex;


### PR DESCRIPTION
- includes math block content when generating quizzes. Previously, only text blocks were sent and math was treated like other media – like images – so the quizzes had to just guess what the card content might be. (GPT seems to handle LaTeX as well as any other code.)
- improve success rate of quiz generation. Sometimes the response included json fencing at the start and end, despite asking it not to. We strip out any fencing in post-processing.
- Change to markdown for rendering quiz text and math quiz content. LaTeX can then be inlined and delimited with $ or $$.
- tweak a few quiz styles: make the target for clicking choices a bit larger, give it the proper pointer, and give it a hover effect.

Other notes:
- The LaTeX rendering isn't 100% perfect – the LLM seems to forget to add `$` as delimiters, but it's pretty good. 
- I tried using MathML directly instead of LaTeX, but that was less successful and bloated the response when it was. 
- Also tried improving rendering by adding delimiters to any undelimited LaTeX, but my simple regex to detect undelimited LaTeX just made things worse.

On dev for testing.