### PR TITLE
Adds ability to clone deck

### DIFF
--- a/app/Policies/DeckPolicy.php
+++ b/app/Policies/DeckPolicy.php
@@ -37,6 +37,11 @@ class DeckPolicy
         return true;
     }
 
+    public function clone(User $user, Deck $deck): bool
+    {
+        return $user->isMemberOfDeck($deck) || $deck->is_public;
+    }
+
     /**
      * Determine whether the user can update the model.
      */

--- a/resources/client/api/index.ts
+++ b/resources/client/api/index.ts
@@ -85,6 +85,29 @@ export async function createDeck(
   return res.data.data;
 }
 
+export async function cloneDeck({
+  sourceDeckId,
+  name,
+  description,
+  isTTSEnabled,
+}: {
+  sourceDeckId: T.Deck["id"];
+  name: string;
+  description: string;
+  isTTSEnabled: boolean;
+}) {
+  const res = await axios.post<{ data: T.Deck }>(
+    `/decks/${sourceDeckId}/clone`,
+    {
+      name,
+      description,
+      is_tts_enabled: isTTSEnabled,
+    },
+  );
+
+  return res.data.data;
+}
+
 export async function deleteDeck(
   deckId: number,
   customConfig: T.CustomAxiosRequestConfig = {},

--- a/resources/client/pages/Decks/CloneDeckPage.vue
+++ b/resources/client/pages/Decks/CloneDeckPage.vue
@@ -1,0 +1,113 @@
+<template>
+  <AuthenticatedLayout>
+    <div class="max-w-screen-md mx-auto">
+      <PageHeader
+        title="Clone Deck"
+        :subtitle="deck?.name"
+        :backTo="backTo"
+        class="mb-8"
+      />
+
+      <main>
+        <form
+          v-if="deck"
+          @submit.prevent="handleClone"
+          class="bg-brand-maroon-800/5 p-4 rounded-lg flex flex-col gap-4"
+        >
+          <div class="text-lg">
+            <p>
+              This will <b>clone</b> the <b>{{ deck?.name }}</b> deck to create
+              a new deck with the same cards. No members or study history will
+              be copied.
+            </p>
+          </div>
+
+          <InputGroup id="cloned-deck-name" label="Name" v-model="form.name" />
+          <InputGroup
+            id="cloned-deck-description"
+            label="Description"
+            v-model="form.description"
+          />
+
+          <div class="flex gap-2 items-center">
+            <Switch
+              id="tts-enabled"
+              :checked="form.isTTSEnabled"
+              @update:checked="form.isTTSEnabled = $event"
+              label="Enable TTS"
+            />
+            <Label for="tts-enabled">
+              Enable Text-to-Speech
+              <HintTooltip>
+                When enabled, a button to read text aloud will be available.
+                This is useful for learning pronunciation.
+              </HintTooltip>
+            </Label>
+          </div>
+
+          <div class="flex items-center justify-end gap-2">
+            <Button asChild variant="secondary">
+              <RouterLink :to="backTo"> Cancel </RouterLink>
+            </Button>
+            <Button type="submit">Clone</Button>
+          </div>
+        </form>
+      </main>
+    </div>
+  </AuthenticatedLayout>
+</template>
+<script setup lang="ts">
+import PageHeader from "@/components/PageHeader.vue";
+import { AuthenticatedLayout } from "@/layouts/AuthenticatedLayout";
+import { computed, reactive, watch } from "vue";
+import { useDeckByIdQuery } from "@/queries/decks";
+import { useRouter } from "vue-router";
+import InputGroup from "@/components/InputGroup.vue";
+import { Button } from "@/components/ui/button";
+import Switch from "@/components/ui/switch/Switch.vue";
+import Label from "@/components/ui/label/Label.vue";
+import HintTooltip from "@/components/HintTooltip.vue";
+
+const props = defineProps<{
+  deckId: number | null;
+}>();
+
+const form = reactive({
+  name: "",
+  description: "",
+  isTTSEnabled: false,
+});
+
+const deckIdRef = computed(() => props.deckId);
+const { data: deck } = useDeckByIdQuery(deckIdRef);
+
+const router = useRouter();
+
+const backTo = computed(() => {
+  return String(router.options.history.state.back) || { name: "decks.index" };
+});
+
+// once we have deck data, use it it populate the form
+// then stop watching
+const unwatchDeck = watch(
+  deck,
+  () => {
+    if (!deck.value) {
+      return;
+    }
+    form.name = `Copy of ${deck.value.name}`;
+    form.description = deck.value.description;
+    form.isTTSEnabled = deck.value.is_tts_enabled;
+
+    unwatchDeck();
+  },
+  {
+    immediate: true,
+  },
+);
+
+function handleClone() {
+  console.log("clone!");
+}
+</script>
+<style scoped></style>

--- a/resources/client/pages/Decks/CloneDeckPage.vue
+++ b/resources/client/pages/Decks/CloneDeckPage.vue
@@ -67,6 +67,8 @@ import { Button } from "@/components/ui/button";
 import Switch from "@/components/ui/switch/Switch.vue";
 import Label from "@/components/ui/label/Label.vue";
 import HintTooltip from "@/components/HintTooltip.vue";
+import { useCloneDeckMutation } from "@/queries/decks/useCloneDeckMutation";
+import invariant from "tiny-invariant";
 
 const props = defineProps<{
   deckId: number | null;
@@ -80,6 +82,7 @@ const form = reactive({
 
 const deckIdRef = computed(() => props.deckId);
 const { data: deck } = useDeckByIdQuery(deckIdRef);
+const { mutate: cloneDeck } = useCloneDeckMutation();
 
 const router = useRouter();
 
@@ -106,8 +109,23 @@ const unwatchDeck = watch(
   },
 );
 
-function handleClone() {
-  console.log("clone!");
+async function handleClone() {
+  invariant(deckIdRef.value, "Deck ID is required to clone a deck");
+
+  cloneDeck(
+    {
+      sourceDeckId: deckIdRef.value,
+      name: form.name,
+      description: form.description,
+      isTTSEnabled: form.isTTSEnabled,
+    },
+    {
+      onSuccess: (newDeck) => {
+        console.log("cloneDeck onSuccess", { newDeck });
+        router.push({ name: "decks.show", params: { deckId: newDeck.id } });
+      },
+    },
+  );
 }
 </script>
 <style scoped></style>

--- a/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
@@ -14,18 +14,10 @@
         </RouterLink>
       </DropdownMenuItem>
       <DropdownMenuItem asChild>
-        <RouterLink
-          :to="{ name: 'decks.practice', params: { deckId: deck.id } }"
-        >
-          <IconCirclePlay class="size-5 mr-4" />
-          Practice
+        <RouterLink :to="{ name: 'decks.clone', params: { deckId: deck.id } }">
+          <IconCopy class="size-5 mr-4" />
+          Clone
         </RouterLink>
-      </DropdownMenuItem>
-      <DropdownMenuItem asChild v-if="deck.capabilities.canUpdate">
-        <button @click="state.isEmbedModalOpen = true" class="block w-full">
-          <IconEmbed class="size-5 mr-4" />
-          Embed
-        </button>
       </DropdownMenuItem>
       <DropdownMenuItem asChild v-if="deck.capabilities.canUpdate">
         <RouterLink
@@ -124,6 +116,7 @@ import Modal from "@/components/Modal.vue";
 import { computed, reactive } from "vue";
 import { useRouter } from "vue-router";
 import EmbedDeckModal from "@/components/EmbedDeckModal.vue";
+import IconCopy from "@/components/icons/IconCopy.vue";
 
 const props = defineProps<{
   deck: T.Deck;

--- a/resources/client/queries/decks/useCloneDeckMutation.ts
+++ b/resources/client/queries/decks/useCloneDeckMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import * as api from "@/api";
+import { DECKS_QUERY_KEY } from "../queryKeys";
+
+export function useCloneDeckMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.cloneDeck,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [DECKS_QUERY_KEY],
+      });
+    },
+  });
+}

--- a/resources/client/router/index.ts
+++ b/resources/client/router/index.ts
@@ -113,6 +113,14 @@ const router = createRouter({
       }),
     },
     {
+      path: "/decks/:deckId/clone",
+      name: "decks.clone",
+      component: () => import("@/pages/Decks/CloneDeckPage.vue"),
+      props: (route) => ({
+        deckId: Number(route.params.deckId),
+      }),
+    },
+    {
       path: "/decks/:deckId/share",
       name: "decks.share",
       component: () => import("../pages/Decks/ShareDeckPage.vue"),

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::middleware(['auth'])
         Route::get('features', [FeatureFlagController::class, 'index']);
 
         Route::resource('decks', DeckController::class);
+        Route::post('decks/{deck}/clone', [DeckController::class, 'clone'])
+            ->name('decks.clone');
 
         Route::resource('decks.memberships', DeckMembershipController::class)
             ->shallow();


### PR DESCRIPTION
Closes #13 

Lets users clone a deck that they're a member of. (e.g faculty want to use a colleague's deck for their own class).

- clone option is available on the Deck's "More Actions" menu
- user will be redirected to cloned deck after clone
- only cards, no member data is copied
- cloning is permitted for any deck member

on dev for testing