### PR TITLE
Fixed watcher cleanup to properly handle temporal dead zone

### DIFF
--- a/resources/client/pages/Decks/CloneDeckPage.vue
+++ b/resources/client/pages/Decks/CloneDeckPage.vue
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import PageHeader from "@/components/PageHeader.vue";
 import { AuthenticatedLayout } from "@/layouts/AuthenticatedLayout";
-import { computed, reactive, watch } from "vue";
+import { computed, nextTick, reactive, watch } from "vue";
 import { useDeckByIdQuery } from "@/queries/decks";
 import { useRouter } from "vue-router";
 import InputGroup from "@/components/InputGroup.vue";
@@ -102,7 +102,10 @@ const unwatchDeck = watch(
     form.description = deck.value.description;
     form.isTTSEnabled = deck.value.is_tts_enabled;
 
-    unwatchDeck();
+    // use nextTick and a closure to avoid `lexical warning`
+    // about undeclared unwatchDeck. This happens because
+    // unwatch is undefined at this point (temporal dead zone).
+    nextTick(() => unwatchDeck());
   },
   {
     immediate: true,


### PR DESCRIPTION
Fixes #126 

Changed the watcher cleanup from directly invoking `unwatchDeck` using `nextTick` with using an arrow function wrapper. This avoids a JavaScript temporal dead zone (TDZ) error where we were trying to access the `unwatchDeck` reference before it was fully initialized, causing a white page.

The error would only occur if deck data was already cached in our query. When the watcher was invoked, it wouldn't need to wait for data, and instead initialize the deck info and tried to unwatch. If the data wasn't cached, the fetch time would be enough for the `unwatch` variable to initialize.

```js
// ❌  Before - would throw Reference Error, since unwatch is undefined in watcher
unwatchDeck()

// ❌ This also doesn't work
nextTick(unwatchDeck)

// ✅  properly defers access of unwatchDeck until after initialization
nextTick(() => unwatchDeck())
```


