### PR TITLE
Move DeckInviteToken creation to Deck model's booted method

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -156,7 +156,10 @@ class DeckController extends Controller
             'role' => 'owner',
         ]);
 
-        return DeckResource::make($newDeck);
+        // refresh to get all attributes like `is_public`
+        return DeckResource::make($newDeck->fresh())
+            ->response()
+            ->setStatusCode(201);
     }
 
     public function stats(Deck $deck)

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -5,10 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Resources\DeckResource;
 use App\Imports\CardsImport;
 use App\Models\Deck;
-use App\Models\DeckInviteToken;
 use Gate;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
 
 class DeckController extends Controller
@@ -48,15 +46,6 @@ class DeckController extends Controller
             'user_id' => $request->user()->id,
             'role' => 'owner',
         ]);
-
-        // Create initial tokens for each permission type
-        foreach (['view', 'edit'] as $permission) {
-            DeckInviteToken::create([
-                'deck_id' => $deck->id,
-                'permission' => $permission,
-                'token' => Str::random(32),
-            ]);
-        }
 
         return DeckResource::make($deck->fresh())
             ->response()

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use OwenIt\Auditing\Auditable as AuditableTrait;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 
@@ -29,6 +30,19 @@ class Deck extends Model implements AuditableContract
         'is_public',
         'is_tts_enabled',
     ];
+
+    protected static function booted()
+    {
+        static::created(function ($deck) {
+            foreach (['view', 'edit'] as $permission) {
+                DeckInviteToken::create([
+                    'deck_id' => $deck->id,
+                    'permission' => $permission,
+                    'token' => Str::random(32),
+                ]);
+            }
+        });
+    }
 
     public function users()
     {

--- a/database/migrations/2024_09_03_015828_seed_example_decks.php
+++ b/database/migrations/2024_09_03_015828_seed_example_decks.php
@@ -2,6 +2,7 @@
 
 use App\Models\Deck;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Events\Dispatcher;
 
 return new class extends Migration
 {
@@ -854,9 +855,17 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Temporarily disable dispatching a `created` event,
+        // which will attempt to create tokens. However, the token
+        // table doesn't exist yet.
+        Deck::unsetEventDispatcher();
+
         $this->addArtHistoryExampleDeck();
         $this->addBeginningItalianExampleDeck();
         $this->addBackyardBirdsDeck();
+
+        // Reset event dispatcher
+        Deck::setEventDispatcher(new Dispatcher);
     }
 
     /**


### PR DESCRIPTION
Fixes #125 

After cloning a deck, a 500 error would be thrown when viewing the Share page. This was due to missing tokens for the newly created deck.

This moves the token creation from the DeckController to the Deck model. The model listens for a Deck's `created` event and then creates the tokens for  view and edit permissions.
