### PR TITLE
fix: matching game shows blank text tiles

### DIFF
--- a/resources/client/components/DeckContextProvider.vue
+++ b/resources/client/components/DeckContextProvider.vue
@@ -1,0 +1,14 @@
+<template>
+  <slot></slot>
+</template>
+<script setup lang="ts">
+import * as T from "@/types";
+import { provideDeckContext } from "@/composables/useDeckContext";
+
+const props = defineProps<{
+  deck: T.Deck;
+}>();
+
+provideDeckContext(() => props.deck);
+</script>
+<style scoped></style>

--- a/resources/client/composables/useDeckContext.ts
+++ b/resources/client/composables/useDeckContext.ts
@@ -1,0 +1,20 @@
+import { provide, inject, toRef, type MaybeRefOrGetter, type Ref } from "vue";
+import * as T from "@/types";
+
+interface DeckContext {
+  deck: Ref<T.Deck>;
+}
+
+const DECK_CONTEXT_KEY = Symbol("deckContext");
+
+export function provideDeckContext(deck: MaybeRefOrGetter<T.Deck>) {
+  const deckContext: DeckContext = {
+    deck: toRef(deck),
+  };
+
+  provide(DECK_CONTEXT_KEY, deckContext);
+}
+
+export function useDeckContext() {
+  return inject(DECK_CONTEXT_KEY) as DeckContext;
+}

--- a/resources/client/pages/Activities/MatchingGamePage/MatchingGamePage.vue
+++ b/resources/client/pages/Activities/MatchingGamePage/MatchingGamePage.vue
@@ -37,11 +37,13 @@
         </Button>
       </div>
 
-      <MatchingGame
-        :cards="deck.cards"
-        class="mx-auto max-h-[66vh] aspect-square"
-        @gameover="handleWin"
-      />
+      <DeckContextProvider :deck="deck">
+        <MatchingGame
+          :cards="deck.cards"
+          class="mx-auto max-h-[66vh] aspect-square"
+          @gameover="handleWin"
+        />
+      </DeckContextProvider>
     </div>
   </AuthenticatedLayout>
 </template>
@@ -56,6 +58,7 @@ import { useCreateDeckActivityEventMutation } from "@/queries/deckActivityEvents
 import LevelProgress from "@/components/LevelProgress.vue";
 import { useDeckStatsQuery } from "@/queries/decks/useDeckStatsQuery";
 import * as T from "@/types";
+import DeckContextProvider from "@/components/DeckContextProvider.vue";
 
 const props = defineProps<{
   deckId: number;

--- a/resources/client/pages/Activities/MatchingGamePage/MatchingSide.vue
+++ b/resources/client/pages/Activities/MatchingGamePage/MatchingSide.vue
@@ -8,54 +8,56 @@
       'cursor-pointer': status !== 'disabled',
     }"
   >
-    <Transition name="fade">
-      <aside
-        v-if="status !== 'idle'"
-        class="absolute inset-0 z-20 rounded-sm font-bold text-4xl px-4 py-3 flex items-center justify-center text-brand-oatmeal-50"
-        :class="{
-          'bg-brand-orange-500/75 backdrop-blur-sm': status === 'mismatch',
-          'bg-brand-teal-300/75 backdrop-blur-sm': status === 'match',
-        }"
-      >
-        <span v-if="status === 'match'">
-          <IconCheck />
-          <span class="sr-only">Match</span>
-        </span>
-        <span v-else-if="status === 'mismatch'">
-          <IconX />
-          <span class="sr-only">Not a match. Try again</span>
-        </span>
-      </aside>
-    </Transition>
-    <div class="flex flex-col gap-4 my-auto py-1 items-start mx-auto">
-      <template v-for="block in blocks" :key="block.id">
-        <TextBlockView
-          v-if="isTextBlock(block)"
-          :block="block"
-          class="text-xs sm:text-base !leading-[1] pointer-events-none"
-        />
-        <ImageBlockView
-          v-else-if="isImageBlock(block)"
-          :src="block.content"
-          :alt="block.meta?.alt ?? ''"
-          :withLightbox="false"
-        />
-        <VideoBlockView v-else-if="isVideoBlock(block)" :block="block" />
-        <EmbedBlockView v-else-if="isEmbedBlock(block)" :block="block" />
-        <SimpleAudioPlayer
-          v-else-if="isAudioBlock(block)"
-          :src="block.content"
-          :isPlaying="status === 'selected'"
-        />
-        <HintBlockView
-          v-else-if="isHintBlock(block)"
-          :modelValue="block.content"
-          :meta="block.meta"
-        />
-        <MathBlockView v-else-if="isMathBlock(block)" :block="block" />
-        <UnknownBlockView v-else :block="block" />
-      </template>
-    </div>
+    <TTSContextProvider :deck="deck ?? null" :cardSideName="label">
+      <Transition name="fade">
+        <aside
+          v-if="status !== 'idle'"
+          class="absolute inset-0 z-20 rounded-sm font-bold text-4xl px-4 py-3 flex items-center justify-center text-brand-oatmeal-50"
+          :class="{
+            'bg-brand-orange-500/75 backdrop-blur-sm': status === 'mismatch',
+            'bg-brand-teal-300/75 backdrop-blur-sm': status === 'match',
+          }"
+        >
+          <span v-if="status === 'match'">
+            <IconCheck />
+            <span class="sr-only">Match</span>
+          </span>
+          <span v-else-if="status === 'mismatch'">
+            <IconX />
+            <span class="sr-only">Not a match. Try again</span>
+          </span>
+        </aside>
+      </Transition>
+      <div class="flex flex-col gap-4 my-auto py-1 items-start mx-auto">
+        <template v-for="block in blocks" :key="block.id">
+          <TextBlockView
+            v-if="isTextBlock(block)"
+            :block="block"
+            class="text-xs sm:text-base !leading-[1] pointer-events-none"
+          />
+          <ImageBlockView
+            v-else-if="isImageBlock(block)"
+            :src="block.content"
+            :alt="block.meta?.alt ?? ''"
+            :withLightbox="false"
+          />
+          <VideoBlockView v-else-if="isVideoBlock(block)" :block="block" />
+          <EmbedBlockView v-else-if="isEmbedBlock(block)" :block="block" />
+          <SimpleAudioPlayer
+            v-else-if="isAudioBlock(block)"
+            :src="block.content"
+            :isPlaying="status === 'selected'"
+          />
+          <HintBlockView
+            v-else-if="isHintBlock(block)"
+            :modelValue="block.content"
+            :meta="block.meta"
+          />
+          <MathBlockView v-else-if="isMathBlock(block)" :block="block" />
+          <UnknownBlockView v-else :block="block" />
+        </template>
+      </div>
+    </TTSContextProvider>
   </div>
 </template>
 <script setup lang="ts">
@@ -79,11 +81,15 @@ import UnknownBlockView from "@/components/CardSideView/UnknownBlockView.vue";
 import SimpleAudioPlayer from "@/components/SimpleAudioPlayer.vue";
 import { IconX, IconCheck } from "@/components/icons";
 import { MatchingCardSide } from "./matchingGameStore";
+import TTSContextProvider from "@/components/TTSContextProvider.vue";
+import { useDeckContext } from "@/composables/useDeckContext";
 
 const props = defineProps<{
   blocks: T.ContentBlock[];
   label: T.CardSideName;
   status: MatchingCardSide["status"];
 }>();
+
+const { deck } = useDeckContext();
 </script>
 <style scoped></style>


### PR DESCRIPTION
The matching card sides are missing the TTS context information (default locales for deck sides, and which deck side we're currently on). This causes the component to not render properly and throw an error:

```
 Error: useTTSContext must be used within a parent provider. Use `provideTTSContext()` to provide the context.
```

The TTSContext needs the deck context. Again, to avoid prop drilling, we create a new context: `<DeckContextProvider>` and wrap the matching game in the context. Then – with the deck info – we pass it along to the `<TTSContextProvider>`.