### PR TITLE
Improve card import UX

### DIFF
--- a/app/Imports/CardsImport.php
+++ b/app/Imports/CardsImport.php
@@ -6,9 +6,10 @@ use App\Models\Card;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Maatwebsite\Excel\Concerns\WithValidation;
 use Str;
 
-class CardsImport implements SkipsEmptyRows, ToModel, WithHeadingRow
+class CardsImport implements SkipsEmptyRows, ToModel, WithHeadingRow, WithValidation
 {
     protected $deckId;
 

--- a/public/examples/french-english.csv
+++ b/public/examples/french-english.csv
@@ -1,0 +1,111 @@
+﻿front,back
+Bonjour,Hello
+Au revoir,Goodbye
+Merci,Thank you
+De rien,You're welcome
+S'il vous plaît,Please
+Excusez-moi,Excuse me
+Comment allez-vous?,How are you?
+Je vais bien,I'm doing well
+Comment vous appelez-vous?,What is your name?
+Je m'appelle...,My name is...
+Où est...?,Where is...?
+Combien ça coûte?,How much does it cost?
+Je ne comprends pas,I don't understand
+Pouvez-vous répéter?,Can you repeat?
+Parlez-vous anglais?,Do you speak English?
+Je ne parle pas français,I don't speak French
+Quelle heure est-il?,What time is it?
+Aujourd'hui,Today
+Hier,Yesterday
+Demain,Tomorrow
+L'eau,Water
+La nourriture,Food
+Le pain,Bread
+Le fromage,Cheese
+Le vin,Wine
+La bière,Beer
+Le café,Coffee
+Le thé,Tea
+La maison,House
+La voiture,Car
+Le train,Train
+L'avion,Airplane
+L'hôtel,Hotel
+Le restaurant,Restaurant
+La banque,Bank
+L'hôpital,Hospital
+L'école,School
+Le travail,Work
+La famille,Family
+Les amis,Friends
+Rouge,Red
+Bleu,Blue
+Vert,Green
+Jaune,Yellow
+Noir,Black
+Blanc,White
+Grand,Big
+Petit,Small
+Chaud,Hot
+Froid,Cold
+Bon,Good
+Mauvais,Bad
+Facile,Easy
+Difficile,Difficult
+Rapide,Fast
+Lent,Slow
+Nouveau,New
+Ancien,Old
+Beau,Beautiful
+Laid,Ugly
+Heureux,Happy
+Triste,Sad
+Fatigué,Tired
+Malade,Sick
+Un,One
+Deux,Two
+Trois,Three
+Quatre,Four
+Cinq,Five
+Six,Six
+Sept,Seven
+Huit,Eight
+Neuf,Nine
+Dix,Ten
+Vingt,Twenty
+Trente,Thirty
+Quarante,Forty
+Cinquante,Fifty
+Cent,One hundred
+Mille,One thousand
+Lundi,Monday
+Mardi,Tuesday
+Mercredi,Wednesday
+Jeudi,Thursday
+Vendredi,Friday
+Samedi,Saturday
+Dimanche,Sunday
+Janvier,January
+Février,February
+Mars,March
+Avril,April
+Mai,May
+Juin,June
+Juillet,July
+Août,August
+Septembre,September
+Octobre,October
+Novembre,November
+Décembre,December
+Le matin,Morning
+L'après-midi,Afternoon
+Le soir,Evening
+La nuit,Night
+Oui,Yes
+Non,No
+Peut-être,Maybe
+Toujours,Always
+Jamais,Never
+Souvent,Often
+Parfois,Sometimes

--- a/resources/client/api/index.ts
+++ b/resources/client/api/index.ts
@@ -250,7 +250,11 @@ export async function getDeckShareLink(
   return res.data.url;
 }
 
-export async function importDeckCards(deckId: number, file: File) {
+export async function importDeckCards(
+  deckId: number,
+  file: File,
+  customConfig: T.CustomAxiosRequestConfig = {},
+) {
   const formData = new FormData();
   formData.append("file", file);
 
@@ -261,6 +265,7 @@ export async function importDeckCards(deckId: number, file: File) {
       headers: {
         "Content-Type": "multipart/form-data",
       },
+      ...customConfig,
     },
   );
   return res.data.data;

--- a/resources/client/components/ui/table/TableHead.vue
+++ b/resources/client/components/ui/table/TableHead.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from 'vue'
-import { cn } from '@/lib/utils'
+import type { HTMLAttributes } from "vue";
+import { cn } from "@/lib/utils";
 
 const props = defineProps<{
-  class?: HTMLAttributes['class']
-}>()
+  class?: HTMLAttributes["class"];
+}>();
 </script>
 
 <template>
-  <th :class="cn('h-10 px-2 text-left align-middle font-medium text-stone-500 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-0.5 dark:text-stone-400', props.class)">
+  <th
+    :class="
+      cn(
+        'h-10 px-2 text-left align-middle font-bold  [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-0.5',
+        props.class,
+      )
+    "
+  >
     <slot />
   </th>
 </template>

--- a/resources/client/pages/Decks/ImportDeckCardsPage.vue
+++ b/resources/client/pages/Decks/ImportDeckCardsPage.vue
@@ -17,12 +17,22 @@
       <main>
         <section class="my-8">
           <p>
-            Import text cards into the <b>{{ deck.name }}</b> deck from a CSV
-            file in the following format:
+            Import text cards into the <b>{{ deck.name }}</b> deck from a
+            spreadsheet (CSV, XLSX) in the following format. The first row of
+            the CSV file <strong>MUST</strong> contain the column headers
+            <code>front</code> and <code>back</code>.
           </p>
 
-          <div class="font-mono border my-4 rounded-lg p-4">
-            <Table>
+          <div class="font-mono border border-black/25 my-4 rounded-lg p-4">
+            <Button
+              class="float-right"
+              variant="secondary"
+              as="a"
+              href="/examples/french-english.csv"
+              download
+              >Download Example</Button
+            >
+            <Table class="font-mono">
               <TableHeader>
                 <TableRow>
                   <TableHead>front</TableHead>

--- a/resources/client/pages/Decks/ImportDeckCardsPage.vue
+++ b/resources/client/pages/Decks/ImportDeckCardsPage.vue
@@ -10,46 +10,66 @@
           {{ deck.name }}
         </RouterLink>
       </nav>
-      <header class="mb-8 pb-8 border-b">
+      <header class="mb-8 pb-8 border-b border-black/10">
         <PageTitle class="mb-2">Import Cards</PageTitle>
         <PageSubtitle>{{ deck.name }}</PageSubtitle>
       </header>
       <main>
         <section class="my-8">
-          <p>
-            Import text cards into the <b>{{ deck.name }}</b> deck from a
-            spreadsheet (CSV, XLSX) in the following format. The first row of
-            the CSV file <strong>MUST</strong> contain the column headers
-            <code>front</code> and <code>back</code>.
+          <p class="my-4">
+            Import cards from a spreadsheet in the following format:
           </p>
 
-          <div class="font-mono border border-black/25 my-4 rounded-lg p-4">
-            <Button
-              class="float-right"
-              variant="secondary"
-              as="a"
-              href="/examples/french-english.csv"
-              download
-              >Download Example</Button
+          <ul class="list-disc ml-6">
+            <li>
+              File extension must be <code>.csv</code>, <code>.xls</code>, or
+              <code>.xlsx</code>.
+            </li>
+            <li>Only text is supported (no images).</li>
+            <li>
+              The first row <strong>must</strong> contain the column headers
+              <code>front</code> and <code>back</code>.
+            </li>
+          </ul>
+
+          <div class="my-4">
+            <div class="flex justify-between items-center mb-2 gap-4 flex-wrap">
+              <h3 class="uppercase text-xs tracking-wider font-bold">
+                Example
+              </h3>
+              <Button
+                variant="secondary"
+                class="text-xs"
+                as="a"
+                href="/examples/french-english.csv"
+                download
+              >
+                <DownloadIcon class="size-4 mr-2" />
+                Download
+              </Button>
+            </div>
+            <div
+              class="mb-2 text-sm border border-black/10 rounded-md bg-white/50 p-2 font-mono"
             >
-            <Table class="font-mono">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>front</TableHead>
-                  <TableHead>back</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell>Bonjour</TableCell>
-                  <TableCell>Hello</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Comment ça va?</TableCell>
-                  <TableCell>How are you?</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>front</TableHead>
+                    <TableHead>back</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow>
+                    <TableCell>Bonjour</TableCell>
+                    <TableCell>Hello</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Comment ça va?</TableCell>
+                    <TableCell>How are you?</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </div>
           </div>
         </section>
 
@@ -66,6 +86,26 @@
             @change="handleFileInputChange"
             accept=".csv, .xls, .xlsx"
           />
+          <div
+            v-if="importError"
+            class="text-red-700 my-4 flex items-center gap-2 bg-red-700/10 p-4 rounded-md text-sm"
+          >
+            <IconExclamationTriangle class="size-6 flex-shrink-0" />
+            <div>
+              <h2 class="uppercase font-bold">Import Error</h2>
+              <p>
+                There was a problem with your import file. Be sure the
+                <b>first row</b> contains headers <code>front</code> and
+                <code>back</code>. If the problem persists, please contact
+                <a
+                  href="mailto:latistecharch@umn.edu"
+                  class="underline text-red-900"
+                  >latistecharch@umn.edu</a
+                >
+                for help.
+              </p>
+            </div>
+          </div>
           <Button
             type="submit"
             v-show="!!selectedFile"
@@ -99,6 +139,7 @@ import { IconExclamationTriangle } from "@/components/icons";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { DownloadIcon } from "@radix-icons/vue";
 
 const props = defineProps<{
   deckId: number;
@@ -107,6 +148,7 @@ const props = defineProps<{
 const fileInput = ref<HTMLInputElement | null>(null);
 const selectedFile = ref<File | null>(null);
 const deckIdRef = computed(() => props.deckId);
+const importError = ref<string | null>(null);
 const { data: deck } = useDeckByIdQuery(deckIdRef);
 
 const router = useRouter();
@@ -125,15 +167,30 @@ async function handleImport() {
     throw new Error("No file selected");
   }
 
-  await api.importDeckCards(props.deckId, selectedFile.value);
-  router.push(`/decks/${props.deckId}`);
+  try {
+    await api.importDeckCards(props.deckId, selectedFile.value, {
+      skipErrorNotifications: true,
+    });
+    router.push(`/decks/${props.deckId}`);
+  } catch (error) {
+    console.error("Error importing cards:", error);
+    if (error instanceof Error) {
+      importError.value = error.message;
+    } else {
+      importError.value = "An unknown error occurred while importing cards.";
+    }
+    selectedFile.value = null;
+    if (fileInput.value) {
+      fileInput.value.value = "";
+    }
+  }
 }
 </script>
 <style scoped>
 code {
-  background-color: hsla(0, 0%, 100%, 0.75);
+  background-color: hsla(0, 0%, 100%, 0.5);
   display: inline-block;
-  padding: 0.25em 0.5em;
+  padding: 0.125em 0.25em;
   border-radius: 0.25em;
 }
 </style>


### PR DESCRIPTION
<img width="500" alt="ScreenShot 2025-09-26 at 08 24 13@2x" src="https://github.com/user-attachments/assets/098cbf03-72a1-4e83-a059-c3ddd46ed134" />

Improves card import UX addressing some common points of confusion like forgetting headers "front" and "back" or believe they can (somehow) import non-text content.

This:

- clarify import requirements
- add button for downloading example CSV
- adds better inline error message when import fails

Fixes #146 
