### PR TITLE
only show `Canvas` labels for Decks where the current user is a member of the lti_resource_link

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -18,7 +18,21 @@ class DeckController extends Controller
     {
         Gate::authorize('viewOwn', Deck::class);
 
-        $decks = $request->user()->decks()->withUserDetails()->get();
+        $decks = $request
+            ->user()
+            ->decks()
+            ->withUserDetails()
+            // include lti resource links for the user
+            // and membership informatino
+            ->with([
+                'ltiResourceLinks' => function ($query) use ($request) {
+                    $query->forUser($request->user())
+                        ->with(['ltiResourceLinkMemberships' => function ($q) use ($request) {
+                            $q->where('user_id', $request->user()->id);
+                        }]);
+                },
+            ])
+            ->get();
 
         return DeckResource::collection($decks);
     }
@@ -68,6 +82,12 @@ class DeckController extends Controller
             ->with([
                 'cards' => function ($query) use ($user) {
                     $query->withUserStats($user);
+                },
+                'ltiResourceLinks' => function ($query) use ($user) {
+                    $query->forUser($user)
+                        ->with(['ltiResourceLinkMemberships' => function ($q) use ($user) {
+                            $q->where('user_id', $user->id);
+                        }]);
                 },
             ])
             ->findOrFail($deckId);

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -23,7 +23,7 @@ class DeckController extends Controller
             ->decks()
             ->withUserDetails()
             // include lti resource links for the user
-            // and membership informatino
+            // and membership information
             ->with([
                 'ltiResourceLinks' => function ($query) use ($request) {
                     $query->forUser($request->user())

--- a/app/Http/Controllers/DeckReportController.php
+++ b/app/Http/Controllers/DeckReportController.php
@@ -32,7 +32,7 @@ class DeckReportController extends Controller
         // Filter to only Canvas courses where user has staff role
         // (Policy ensures user has staff role in at least one course)
         $resourceLinks = $deck->ltiResourceLinks()
-            ->whereHas('memberships', function ($query) {
+            ->whereHas('ltiResourceLinkMemberships', function ($query) {
                 $query->where('user_id', Auth::id())
                     ->where('is_staff', true);
             })

--- a/app/Http/Resources/DeckResource.php
+++ b/app/Http/Resources/DeckResource.php
@@ -31,6 +31,7 @@ class DeckResource extends JsonResource
                 'role' => $this->current_user_role ?? null,
                 'xp' => $this->current_user_xp ?? 0,
                 'last_activity_at' => $this->last_activity_at ?? null,
+                'lti_resource_links' => LtiResourceLinkResource::collection($this->whenLoaded('ltiResourceLinks')),
             ],
 
             'cards' => CardResource::collection($this->whenLoaded('cards')),
@@ -39,8 +40,6 @@ class DeckResource extends JsonResource
 
             // TODO: use current_user_details.role instead
             'current_user_role' => $this->current_user_role,
-
-            'has_lti_resource_links' => $this->ltiResourceLinks()->exists(),
 
             'capabilities' => [
                 'canUpdate' => $request->user()->can('update', $this->resource),

--- a/app/Http/Resources/LtiResourceLinkResource.php
+++ b/app/Http/Resources/LtiResourceLinkResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class LtiResourceLinkResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $membership = $this->ltiResourceLinkMemberships->first();
+
+        return [
+            'id' => $this->id,
+            'resource_link_id' => $this->resource_link_id,
+            'title' => $this->title,
+            'context_id' => $this->context_id,
+            'context_title' => $this->context_title,
+            'context_label' => $this->context_label,
+            'current_user_role' => $membership?->is_staff
+                ? 'staff'
+                : 'student',
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/LtiResourceLinkResource.php
+++ b/app/Http/Resources/LtiResourceLinkResource.php
@@ -14,7 +14,9 @@ class LtiResourceLinkResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $membership = $this->ltiResourceLinkMemberships->first();
+        $membership = $this->relationLoaded('ltiResourceLinkMemberships')
+            ? $this->ltiResourceLinkMemberships->first()
+            : null;
 
         return [
             'id' => $this->id,

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -81,6 +81,16 @@ class Deck extends Model implements AuditableContract
         return $this->hasMany(LtiResourceLink::class);
     }
 
+    public function ltiResourceLinkMemberships()
+    {
+        return $this->hasManyThrough(
+            LtiResourceLinkMembership::class,
+            LtiResourceLink::class,
+            'deck_id',
+            'lti_resource_link_id'
+        );
+    }
+
     public function ltiGradeSubmissions()
     {
         return $this->hasManyThrough(
@@ -241,7 +251,7 @@ class Deck extends Model implements AuditableContract
 
     public function addOrPromoteUserToRole(User $user, string $membershipRole): void
     {
-        if (!DeckMembership::isValidRole($membershipRole)) {
+        if (! DeckMembership::isValidRole($membershipRole)) {
             throw new \InvalidArgumentException("Invalid membership role: {$membershipRole}");
         }
 
@@ -249,11 +259,12 @@ class Deck extends Model implements AuditableContract
             ['user_id' => $user->id]
         );
 
-        $isNew = !$membership->exists;
+        $isNew = ! $membership->exists;
 
         if ($isNew) {
             $membership->role = $membershipRole;
             $membership->save();
+
             return;
         }
 

--- a/app/Models/LtiResourceLink.php
+++ b/app/Models/LtiResourceLink.php
@@ -88,13 +88,13 @@ class LtiResourceLink extends Model
      */
     public function hasAgs(): bool
     {
-        return !empty($this->lineitem_url) || !empty($this->lineitems_url);
+        return ! empty($this->lineitem_url) || ! empty($this->lineitems_url);
     }
 
     /**
      * Get all memberships for this resource link
      */
-    public function memberships()
+    public function ltiResourceLinkMemberships()
     {
         return $this->hasMany(LtiResourceLinkMembership::class, 'lti_resource_link_id');
     }
@@ -102,9 +102,9 @@ class LtiResourceLink extends Model
     /**
      * Get only staff memberships (instructors, TAs, etc.)
      */
-    public function staffMemberships()
+    public function staffLtiResourceLinkMemberships()
     {
-        return $this->memberships()->where('is_staff', true);
+        return $this->ltiResourceLinkMemberships()->where('is_staff', true);
     }
 
     /**
@@ -112,8 +112,18 @@ class LtiResourceLink extends Model
      */
     public function userHasStaffRole(User $user): bool
     {
-        return $this->staffMemberships()
+        return $this->staffLtiResourceLinkMemberships()
             ->where('user_id', $user->id)
             ->exists();
+    }
+
+    /**
+     * Scope to only include resource links where the user has a membership
+     */
+    public function scopeForUser($query, User $user)
+    {
+        return $query->whereHas('ltiResourceLinkMemberships', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        });
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -117,6 +117,18 @@ class User extends Authenticatable implements AuditableContract
         return $this->hasMany(LtiResourceLinkMembership::class);
     }
 
+    public function ltiResourceLinks()
+    {
+        return $this->hasManyThrough(
+            LtiResourceLink::class,
+            LtiResourceLinkMembership::class,
+            'user_id',
+            'id',
+            'id',
+            'lti_resource_link_id'
+        );
+    }
+
     /**
      * Get only staff memberships (where user is instructor/TA)
      */

--- a/resources/client/pages/Decks/DeckIndexPage/DeckListItem.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/DeckListItem.vue
@@ -12,7 +12,7 @@
   >
     <aside class="flex justify-between items-center gap-1">
       <Badge
-        v-if="hasLtiResourceLinksForCurrentUser"
+        v-if="deck.current_user_details.lti_resource_links.length"
         variant="secondary"
         class="text-[0.6rem]"
       >
@@ -88,9 +88,5 @@ const xpEarnedForCurrentLevel = computed(() =>
 
 const percentToNextLevel = computed(() => {
   return (xpEarnedForCurrentLevel.value / xpNeeded.value) * 100;
-});
-
-const hasLtiResourceLinksForCurrentUser = computed(() => {
-  return props.deck.current_user_details.lti_resource_links.length > 0;
 });
 </script>

--- a/resources/client/pages/Decks/DeckIndexPage/DeckListItem.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/DeckListItem.vue
@@ -12,7 +12,7 @@
   >
     <aside class="flex justify-between items-center gap-1">
       <Badge
-        v-if="deck.has_lti_resource_links"
+        v-if="hasLtiResourceLinksForCurrentUser"
         variant="secondary"
         class="text-[0.6rem]"
       >
@@ -76,12 +76,6 @@ const props = defineProps<{
 
 const cardCount = computed(() => props.deck.cards_count ?? 0);
 
-// const randInt = (min: number, max: number) =>
-//   Math.floor(Math.random() * (max - min + 1) + min);
-
-// const randomPercent = randInt(1, 100);
-// const randomLevel = randInt(1, 10);
-
 const totalXP = computed(() => props.deck.current_user_details.xp);
 
 const currentLevel = computed(() => getLevelFromTotalXP(totalXP.value));
@@ -94,5 +88,9 @@ const xpEarnedForCurrentLevel = computed(() =>
 
 const percentToNextLevel = computed(() => {
   return (xpEarnedForCurrentLevel.value / xpNeeded.value) * 100;
+});
+
+const hasLtiResourceLinksForCurrentUser = computed(() => {
+  return props.deck.current_user_details.lti_resource_links.length > 0;
 });
 </script>

--- a/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
+++ b/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
@@ -9,7 +9,7 @@
     >
       <template #title-append>
         <Badge
-          v-if="deck.has_lti_resource_links"
+          v-if="deck.current_user_details.lti_resource_links.length"
           variant="secondary"
           class="text-xs border border-brand-maroon-900/10"
         >
@@ -21,7 +21,7 @@
         <Button asChild variant="outline">
           <RouterLink
             v-if="
-              deck.capabilities.canViewGrades && deck.has_lti_resource_links
+              deck.capabilities.canViewGrades && deck.current_user_details.lti_resource_links.length
             "
             :to="{ name: 'decks.reports.grades', params: { deckId } }"
           >

--- a/resources/client/pages/Decks/ShareDeckPage.vue
+++ b/resources/client/pages/Decks/ShareDeckPage.vue
@@ -49,7 +49,7 @@
           class="bg-brand-oatmeal-50 p-4 rounded-md border border-brand-maroon-900/10"
         >
           <h3 class="text-xl font-bold mb-4">Embed Deck</h3>
-          <div v-if="deck.has_lti_resource_links">
+          <div v-if="deck.current_user_details.lti_resource_links.length">
             <p class="mb-4">
               This deck is linked to Canvas. To embed in your course:
             </p>

--- a/resources/client/types/index.ts
+++ b/resources/client/types/index.ts
@@ -74,13 +74,22 @@ export interface Deck {
   tts_locale_back: string; //  "es-MX", "auto"
   tts_locale_front: string;
   current_user_role: MembershipRole | null; // could be null if public deck
-  has_lti_resource_links: number;
-
   current_user_details: {
     user_id: User["id"];
     role: MembershipRole | null; // could be null if viewing public deck
     xp: number;
     last_activity_at: ISODateTime | null;
+    lti_resource_links: Array<{
+      id: number;
+      resource_link_id: string;
+      title: string;
+      context_id: string; // canvas course id
+      context_label: string; // canvas course code
+      context_title: string; // canvas course name
+      current_user_role: "student" | "staff";
+      created_at: ISODateTime;
+      updated_at: ISODateTime;
+    }>;
   };
 
   current_user_last_activity_at: ISODateTime; //current user's last activity


### PR DESCRIPTION
Updates when`Canvas` label is shown on a deck. Previously, the label would be shown to deck owners if the deck had ANY associated `lti_resource_link`s. Now, it will only appear if the current user has a `lti_resource_link_membership` for the given deck.

 