### PR TITLE
improve lti practice embedding

### DIFF
--- a/app/Services/Lti/LtiService.php
+++ b/app/Services/Lti/LtiService.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Packback\Lti1p3\DeepLinkResources\Iframe;
 use Packback\Lti1p3\DeepLinkResources\Resource;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
@@ -123,7 +124,12 @@ class LtiService
                 // setting the deck as a custom param should let us
                 // link back to the deck when course is cloned
                 'deck_id' => $deckId,
-            ]);
+            ])
+            ->setIframe(
+                Iframe::new()
+                    ->setWidth(800)
+                    ->setHeight(640)
+            );
 
         // Get JWT for the response
         $jwt = $deeplink->getResponseJwt([$resource]);

--- a/resources/client/components/CardSideView/CardSideView.vue
+++ b/resources/client/components/CardSideView/CardSideView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="rounded-lg p-2 flex flex-col gap-4 border border-black/20"
+    class="card-side-view rounded-lg p-2 flex flex-col gap-4 border border-black/20"
     :data-cy="`card-side-view--${label}`"
   >
     <h2 class="text-xs uppercase text-center text-black/30" v-if="showLabel">

--- a/resources/client/components/CardStackVisualization.vue
+++ b/resources/client/components/CardStackVisualization.vue
@@ -13,11 +13,11 @@
       <div
         v-for="(cardData, index) in visibleCards"
         :key="cardData.key"
-        class="stack-card absolute rounded border"
+        class="stack-card absolute rounded border rotate-[30deg]"
         :class="{
-          'bg-brand-oatmeal-50 border-brand-maroon-800 shadow-sm':
+          'bg-brand-oatmeal-50 border-brand-maroon-900/50 shadow-sm':
             index === 0 && animationState !== 'reinserting',
-          'bg-brand-oatmeal-300/50 border-brand-maroon-800/30':
+          'bg-[#f0ddcf] border-brand-maroon-800/30':
             index > 0 || animationState === 'reinserting',
           'animate-puff-out': animationState === 'removing' && index === 0,
           'animate-shuffle-card': animationState === 'reinserting',
@@ -46,8 +46,8 @@ const props = defineProps<{
   reinsertionIndex: number | null;
 }>();
 
-const CARD_WIDTH = 40;
-const CARD_HEIGHT = 28;
+const CARD_WIDTH = 18;
+const CARD_HEIGHT = 24;
 const CARD_OFFSET_X = 8;
 const MAX_VISIBLE_CARDS = 50;
 

--- a/resources/client/components/LevelProgress.vue
+++ b/resources/client/components/LevelProgress.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex gap-4 items-center">
+  <div class="level-progress flex gap-4 items-center">
     <span
       class="flex-shrink-0 text-brand-maroon-900/50 uppercase text-xs font-bold"
     >

--- a/resources/client/components/LevelProgress.vue
+++ b/resources/client/components/LevelProgress.vue
@@ -12,7 +12,6 @@
   </div>
 </template>
 <script setup lang="ts">
-import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { computed } from "vue";
 import {

--- a/resources/client/layouts/EmbedLayout.vue
+++ b/resources/client/layouts/EmbedLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-dvh bg-brand-oatmeal-100 w-full">
+  <div :class="cn('min-h-dvh w-full', props.class)">
     <div :class="cn('pt-6 sm:py-10', containerClass)">
       <div :class="cn('px-4 sm:px-6')">
         <slot />
@@ -9,10 +9,11 @@
 </template>
 
 <script setup lang="ts">
-import * as T from "@/types";
 import { cn } from "@/lib/utils";
+import * as T from "@/types";
 
-defineProps<{
+const props = defineProps<{
+  class?: T.CSSClass;
   containerClass?: T.CSSClass;
 }>();
 </script>

--- a/resources/client/layouts/EmbedLayout.vue
+++ b/resources/client/layouts/EmbedLayout.vue
@@ -1,9 +1,7 @@
 <template>
-  <div :class="cn('min-h-dvh w-full', props.class)">
-    <div :class="cn('pt-6 sm:py-10', containerClass)">
-      <div :class="cn('px-4 sm:px-6')">
-        <slot />
-      </div>
+  <div :class="cn('embed-layout min-h-dvh w-full', props.class)">
+    <div :class="cn('p-4', containerClass)">
+      <slot />
     </div>
   </div>
 </template>

--- a/resources/client/pages/Activities/ActivityPageHeader.vue
+++ b/resources/client/pages/Activities/ActivityPageHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="flex flex-col mb-8 rounded-xl mx-auto max-w-screen-sm gap-6">
+  <header class="rounded-xl mx-auto max-w-screen-sm">
     <div
       class="flex gap-4 flex-wrap items-center"
       :class="{

--- a/resources/client/pages/Activities/MatchingGamePage/MatchingGameEmbedPage.vue
+++ b/resources/client/pages/Activities/MatchingGamePage/MatchingGameEmbedPage.vue
@@ -3,11 +3,11 @@
     <ActivityPageHeader title="Matching" :subtitle="deck?.name ?? ''">
       <LevelProgress
         :xp="deckStats?.current_user_xp ?? 0"
-        class="w-full px-2"
+        class="w-full mt-2"
       />
     </ActivityPageHeader>
 
-    <div v-if="deck" class="max-w-screen-sm mx-auto">
+    <div v-if="deck" class="max-w-screen-sm mx-auto mt-6">
       <div
         v-if="deck.cards.length < 2"
         class="bg-brand-oatmeal-50 p-4 rounded-xl text-center max-w-screen-sm mx-auto"
@@ -67,4 +67,8 @@ async function handleWin(matchedPairs: number) {
   });
 }
 </script>
-<style scoped></style>
+<style>
+.embed-layout .matching-side {
+  background: white;
+}
+</style>

--- a/resources/client/pages/Activities/MatchingGamePage/MatchingSide.vue
+++ b/resources/client/pages/Activities/MatchingGamePage/MatchingSide.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-brand-oatmeal-50 shadow-sm border border-brand-oatmeal-300 rounded-sm aspect-square relative flex flex-col p-1 overflow-auto scrollbar-thin scrollbar-thumb-black/10 scrollbar-track-transparent"
+    class="matching-side bg-brand-oatmeal-50 shadow-sm border border-brand-oatmeal-300 rounded-sm aspect-square relative flex flex-col p-1 overflow-auto scrollbar-thin scrollbar-thumb-black/10 scrollbar-track-transparent"
     :class="{
       'ring-2 ring-brand-teal-300 ring-offset-2 bg-brand-teal-100 shadow-sm':
         status === 'selected',

--- a/resources/client/pages/Activities/PracticeDeckPage/PracticeDeck.vue
+++ b/resources/client/pages/Activities/PracticeDeckPage/PracticeDeck.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="practice-deck">
     <div
       v-if="!state.activeCard"
       class="flex flex-col items-center justify-center py-12 bg-brand-oatmeal-50 rounded-md shadow-sm"

--- a/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
+++ b/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <EmbedLayout>
+  <EmbedLayout class="practice-deck-embed-page">
     <Alert
       v-if="isLtiLaunch && hasCompletedPractice"
       type="success"
@@ -70,5 +70,10 @@ button {
   &:hover {
     text-decoration: none;
   }
+}
+</style>
+<style>
+.practice-deck-embed-page .card-side-view {
+  background: white;
 }
 </style>

--- a/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
+++ b/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
@@ -12,7 +12,7 @@
       </template>
     </ActivityPageHeader>
 
-    <div>
+    <div class="mt-6">
       <div v-if="isDeckLoading" class="text-center">...</div>
       <div v-else-if="deck && deck.cards.length < 2" class="text-center">
         <p>You need at least 2 cards to practice.</p>
@@ -32,7 +32,7 @@
     </div>
     <LevelProgress
       :xp="deckStats?.current_user_xp ?? 0"
-      class="w-full px-4 py-2 fixed bottom-0 left-0 right-0 max-w-screen-sm mx-auto"
+      class="w-full px-4 mt-8 max-w-screen-sm mx-auto"
     />
   </EmbedLayout>
 </template>
@@ -75,5 +75,9 @@ button {
 <style>
 .practice-deck-embed-page .card-side-view {
   background: white;
+}
+.practice-deck-embed-page .flippable-card {
+  height: 20rem;
+  max-width: 30rem;
 }
 </style>

--- a/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
+++ b/resources/client/pages/Activities/PracticeDeckPage/PracticeDeckEmbedPage.vue
@@ -32,7 +32,7 @@
     </div>
     <LevelProgress
       :xp="deckStats?.current_user_xp ?? 0"
-      class="w-full px-4 mt-8 max-w-screen-sm mx-auto"
+      class="w-full max-w-screen-sm mx-auto fixed bottom-0 left-0 right-0 py-2 px-4"
     />
   </EmbedLayout>
 </template>
@@ -79,5 +79,12 @@ button {
 .practice-deck-embed-page .flippable-card {
   height: 20rem;
   max-width: 30rem;
+}
+.practice-deck-embed-page .level-progress {
+  display: none;
+
+  @media (min-height: 640px) {
+    display: block;
+  }
 }
 </style>

--- a/resources/client/pages/Activities/QuizDeckPage/QuizDeckEmbedPage.vue
+++ b/resources/client/pages/Activities/QuizDeckPage/QuizDeckEmbedPage.vue
@@ -1,14 +1,14 @@
 <template>
-  <EmbedLayout>
+  <EmbedLayout class="quiz-deck-embed-page">
     <ActivityPageHeader title="Practice Quiz" :subtitle="deck?.name">
       <LevelProgress
         :xp="deckStats?.current_user_xp ?? 0"
-        class="w-full px-2"
+        class="w-full mt-2"
       />
     </ActivityPageHeader>
 
     <div
-      class="p-4 sm:p-8 pb-8 sm:pb-12 rounded-xl mx-auto max-w-screen-sm bg-brand-oatmeal-50"
+      class="p-4 sm:p-8 pb-8 sm:pb-12 rounded-xl mx-auto max-w-screen-sm bg-white mt-6"
     >
       <section class="flex flex-col gap-4" v-if="state.quizState === 'setup'">
         <h2 class="text-center font-bold text-xl">Set Up</h2>


### PR DESCRIPTION
- sets default height for embedded iframe to `640`
- tweaks padding/margin to buy a little more space
- hides "Level" bar if height is too short
- adds a little rotation to "cards left" visual to help distinguish the card more clearly from an input field

<img width="800"  alt="ScreenShot 2026-01-13 at 14 02 19@2x" src="https://github.com/user-attachments/assets/35b42488-4164-40ac-be03-ed2e9898427e" />

On dev