### PR TITLE
Add History page for Owners

### DIFF
--- a/app/Http/Controllers/DeckAuditController.php
+++ b/app/Http/Controllers/DeckAuditController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Card;
+use App\Models\Deck;
+use Illuminate\Support\Facades\Gate;
+use OwenIt\Auditing\Models\Audit;
+
+class DeckAuditController extends Controller
+{
+    public function index(Deck $deck)
+    {
+        Gate::authorize('viewAuditHistory', [Deck::class, $deck]);
+
+        $cardIds = $deck->cards()->withTrashed()->pluck('id');
+
+        $audits = Audit::query()
+            ->where(function ($query) use ($deck, $cardIds) {
+                $query->where(function ($q) use ($deck) {
+                    $q->where('auditable_type', Deck::class)
+                        ->where('auditable_id', $deck->id);
+                })
+                ->orWhere(function ($q) use ($cardIds) {
+                    $q->where('auditable_type', Card::class)
+                        ->whereIn('auditable_id', $cardIds);
+                });
+            })
+            ->with('user:id,name,email')
+            ->orderByDesc('created_at')
+            ->paginate(50);
+
+        return response()->json([
+            'data' => $audits->map(fn (Audit $audit) => [
+                'id' => $audit->id,
+                'event' => $audit->event,
+                'auditable_type' => class_basename($audit->auditable_type),
+                'auditable_id' => $audit->auditable_id,
+                'old_values' => $audit->old_values,
+                'new_values' => $audit->new_values,
+                'user' => $audit->user ? [
+                    'id' => $audit->user->id,
+                    'name' => $audit->user->name,
+                    'email' => $audit->user->email,
+                ] : null,
+                'created_at' => $audit->created_at,
+            ]),
+            'meta' => [
+                'current_page' => $audits->currentPage(),
+                'last_page' => $audits->lastPage(),
+                'per_page' => $audits->perPage(),
+                'total' => $audits->total(),
+            ],
+            'links' => [
+                'prev' => $audits->previousPageUrl(),
+                'next' => $audits->nextPageUrl(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/DeckAuditController.php
+++ b/app/Http/Controllers/DeckAuditController.php
@@ -2,59 +2,92 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\AuditResource;
 use App\Models\Card;
 use App\Models\Deck;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 use OwenIt\Auditing\Models\Audit;
 
 class DeckAuditController extends Controller
 {
-    public function index(Deck $deck)
+    public function index(Request $request, Deck $deck)
     {
         Gate::authorize('viewAuditHistory', [Deck::class, $deck]);
 
+        $validated = $request->validate([
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'object' => ['sometimes', 'string', Rule::in(['Deck', 'Card'])],
+            'id' => ['sometimes', 'integer', 'min:1'],
+            'action' => ['sometimes', 'string', Rule::in(['created', 'updated', 'deleted', 'restored'])],
+            'user' => ['sometimes', 'string', 'max:255'],
+            'from' => ['sometimes', 'date', 'date_format:Y-m-d'],
+            'to' => ['sometimes', 'date', 'date_format:Y-m-d', 'after_or_equal:from'],
+            'sort' => ['sometimes', 'string', Rule::in(['auditable_type', 'event', 'user', 'created_at'])],
+            'direction' => ['sometimes', 'string', Rule::in(['asc', 'desc'])],
+        ]);
+
+        // include soft-deleted cards in the audit trail
         $cardIds = $deck->cards()->withTrashed()->pluck('id');
 
-        $audits = Audit::query()
-            ->where(function ($query) use ($deck, $cardIds) {
-                $query->where(function ($q) use ($deck) {
-                    $q->where('auditable_type', Deck::class)
+        $query = Audit::query()
+            // wrap in `where` to group the OR conditions
+            ->where(function ($q) use ($deck, $cardIds) {
+                // (auditable_type = Deck::class AND auditable_id = $deck->id)
+                $q->where(function ($inner) use ($deck) {
+                    $inner->where('auditable_type', Deck::class)
                         ->where('auditable_id', $deck->id);
                 })
-                ->orWhere(function ($q) use ($cardIds) {
-                    $q->where('auditable_type', Card::class)
-                        ->whereIn('auditable_id', $cardIds);
+                    // OR (auditable_type = Card::class AND auditable_id IN ($cardIds))
+                    ->orWhere(function ($inner) use ($cardIds) {
+                        $inner->where('auditable_type', Card::class)
+                            ->whereIn('auditable_id', $cardIds);
+                    });
+            })
+            ->with('user:id,name,email');
+
+        // add filters
+        $query
+            ->when($validated['object'] ?? false, function ($q) use ($validated) {
+                $objectType = $validated['object'] === 'Deck'
+                    ? Deck::class
+                    : Card::class;
+                $q->where('auditable_type', $objectType);
+            })
+            ->when($validated['id'] ?? false, function ($q) use ($validated) {
+                $q->where('auditable_id', $validated['id']);
+            })
+            ->when($validated['action'] ?? false, function ($q) use ($validated) {
+                $q->where('event', $validated['action']);
+            })
+            ->when($validated['user'] ?? false, function ($q) use ($validated) {
+                $q->whereHas('user', function ($subQ) use ($validated) {
+                    $subQ->where('name', 'like', '%'.$validated['user'].'%');
                 });
             })
-            ->with('user:id,name,email')
-            ->orderByDesc('created_at')
-            ->paginate(50);
+            ->when($validated['from'] ?? false, function ($q) use ($validated) {
+                $q->whereDate('created_at', '>=', $validated['from']);
+            })
+            ->when($validated['to'] ?? false, function ($q) use ($validated) {
+                $q->whereDate('created_at', '<=', $validated['to']);
+            });
 
-        return response()->json([
-            'data' => $audits->map(fn (Audit $audit) => [
-                'id' => $audit->id,
-                'event' => $audit->event,
-                'auditable_type' => class_basename($audit->auditable_type),
-                'auditable_id' => $audit->auditable_id,
-                'old_values' => $audit->old_values,
-                'new_values' => $audit->new_values,
-                'user' => $audit->user ? [
-                    'id' => $audit->user->id,
-                    'name' => $audit->user->name,
-                    'email' => $audit->user->email,
-                ] : null,
-                'created_at' => $audit->created_at,
-            ]),
-            'meta' => [
-                'current_page' => $audits->currentPage(),
-                'last_page' => $audits->lastPage(),
-                'per_page' => $audits->perPage(),
-                'total' => $audits->total(),
-            ],
-            'links' => [
-                'prev' => $audits->previousPageUrl(),
-                'next' => $audits->nextPageUrl(),
-            ],
-        ]);
+        // Sorting
+        $sortField = $validated['sort'] ?? 'created_at';
+        $sortDirection = $validated['direction'] ?? 'desc';
+
+        if ($sortField === 'user') {
+            $query->leftJoin('users', 'audits.user_id', '=', 'users.id')
+                ->orderBy('users.name', $sortDirection)
+                // only return audit cols, join is just for sorting
+                // this avoids ambiguous column errors
+                // (e.g. audit.id vs users.id)
+                ->select('audits.*');
+        } else {
+            $query->orderBy($sortField, $sortDirection);
+        }
+
+        return AuditResource::collection($query->paginate(50));
     }
 }

--- a/app/Http/Controllers/DeckAuditController.php
+++ b/app/Http/Controllers/DeckAuditController.php
@@ -24,7 +24,7 @@ class DeckAuditController extends Controller
             'user' => ['sometimes', 'string', 'max:255'],
             'from' => ['sometimes', 'date', 'date_format:Y-m-d'],
             'to' => ['sometimes', 'date', 'date_format:Y-m-d', 'after_or_equal:from'],
-            'sort' => ['sometimes', 'string', Rule::in(['auditable_type', 'event', 'user', 'created_at'])],
+            'sort' => ['sometimes', 'string', Rule::in(['auditable_type', 'auditable_id', 'event', 'user', 'created_at'])],
             'direction' => ['sometimes', 'string', Rule::in(['asc', 'desc'])],
         ]);
 

--- a/app/Http/Controllers/DeckReportController.php
+++ b/app/Http/Controllers/DeckReportController.php
@@ -11,10 +11,26 @@ class DeckReportController extends Controller
     {
         Gate::authorize('viewReports', [Deck::class, $deck]);
 
+        $cards = $deck->cards()
+            ->withGlobalStats()
+            ->withAuditInfo()
+            ->get()
+            ->map(fn ($card) => [
+                ...$card->toArray(),
+                'created_by' => $card->created_by ? [
+                    'id' => $card->created_by->id,
+                    'name' => $card->created_by->name,
+                ] : null,
+                'updated_by' => $card->updated_by ? [
+                    'id' => $card->updated_by->id,
+                    'name' => $card->updated_by->name,
+                ] : null,
+            ]);
+
         return response()->json([
             'cards_count' => $deck->cards()->count(),
             'memberships_count' => $deck->memberships()->count(),
-            'cards_with_stats' => $deck->cards()->withGlobalStats()->get(),
+            'cards_with_stats' => $cards,
             'memberships_with_stats' => $deck
                 ->memberships()
                 ->with('user')

--- a/app/Http/Resources/AuditResource.php
+++ b/app/Http/Resources/AuditResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AuditResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'event' => $this->event,
+            'auditable_type' => class_basename($this->auditable_type),
+            'auditable_id' => $this->auditable_id,
+            'old_values' => $this->old_values,
+            'new_values' => $this->new_values,
+            'user' => $this->user ? [
+                'id' => $this->user->id,
+                'name' => $this->user->name,
+                'email' => $this->user->email,
+            ] : null,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/Http/Resources/DeckResource.php
+++ b/app/Http/Resources/DeckResource.php
@@ -47,6 +47,7 @@ class DeckResource extends JsonResource
                 'canViewMemberships' => $request->user()->can('viewMemberships', $this->resource),
                 'canCreateMembership' => $request->user()->can('createMembership', $this->resource),
                 'canViewReports' => $request->user()->can('viewReports', $this->resource),
+                'canViewAuditHistory' => $request->user()->can('viewAuditHistory', $this->resource),
                 'canViewGrades' => $request->user()->can('viewGrades', $this->resource),
                 'canCreateCards' => $request->user()->can('createCards', $this->resource),
                 'canLeave' => $request->user()->can('leave', $this->resource),

--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -48,6 +48,51 @@ class Card extends Model implements AuditableContract
             ]);
     }
 
+    /**
+     * Scope to load audit trail info: who created and who last updated each card.
+     */
+    public function scopeWithAuditInfo(Builder $query): Builder
+    {
+        return $query->with([
+            'audits' => function ($q) {
+                $q->with('user:id,name,email')
+                    ->whereIn('event', ['created', 'updated'])
+                    ->orderBy('created_at', 'asc');
+            },
+        ]);
+    }
+
+    /**
+     * Get the user who created this card from the audits table.
+     */
+    public function getCreatedByAttribute(): ?User
+    {
+        if (!$this->relationLoaded('audits')) {
+            return null;
+        }
+
+        $createdAudit = $this->audits->firstWhere('event', 'created');
+
+        return $createdAudit?->user;
+    }
+
+    /**
+     * Get the user who last updated this card from the audits table.
+     */
+    public function getUpdatedByAttribute(): ?User
+    {
+        if (!$this->relationLoaded('audits')) {
+            return null;
+        }
+
+        $updatedAudit = $this->audits
+            ->where('event', 'updated')
+            ->sortByDesc('created_at')
+            ->first();
+
+        return $updatedAudit?->user;
+    }
+
     public function scopeWithLastAttemptedAt(Builder $query, User $user)
     {
         return $query

--- a/app/Policies/DeckPolicy.php
+++ b/app/Policies/DeckPolicy.php
@@ -95,6 +95,11 @@ class DeckPolicy
         return $user->isOwnerOfDeck($deck);
     }
 
+    public function viewAuditHistory(User $user, Deck $deck): bool
+    {
+        return $user->isOwnerOfDeck($deck);
+    }
+
     public function viewGrades(User $user, Deck $deck): bool
     {
         if (!$user->isOwnerOfDeck($deck)) {

--- a/resources/client/api/index.ts
+++ b/resources/client/api/index.ts
@@ -364,10 +364,25 @@ export async function getDeckSummaryReport(deckId: number) {
   return res.data;
 }
 
-export async function getDeckAuditHistory(deckId: number, page = 1) {
+export interface AuditHistoryParams {
+  page?: number;
+  object?: string;
+  action?: string;
+  user?: string;
+  id?: string;
+  from?: string;
+  to?: string;
+  sort?: string;
+  direction?: "asc" | "desc";
+}
+
+export async function getDeckAuditHistory(
+  deckId: number,
+  params: AuditHistoryParams = {},
+) {
   const res = await axios.get<T.DeckAuditHistoryResponse>(
     `/decks/${deckId}/reports/audit-history`,
-    { params: { page } },
+    { params },
   );
   return res.data;
 }

--- a/resources/client/api/index.ts
+++ b/resources/client/api/index.ts
@@ -364,6 +364,14 @@ export async function getDeckSummaryReport(deckId: number) {
   return res.data;
 }
 
+export async function getDeckAuditHistory(deckId: number, page = 1) {
+  const res = await axios.get<T.DeckAuditHistoryResponse>(
+    `/decks/${deckId}/reports/audit-history`,
+    { params: { page } },
+  );
+  return res.data;
+}
+
 export async function getAssignmentsForDeck(deckId: number) {
   const res = await axios.get<{ data: T.LtiResourceLinkEntry[] }>(
     `/decks/${deckId}/assignments`,

--- a/resources/client/components/icons/IconHistory.vue
+++ b/resources/client/components/icons/IconHistory.vue
@@ -1,0 +1,20 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <!-- Icon from Material Symbols Light by Google - https://github.com/google/material-design-icons/blob/master/LICENSE -->
+    <path
+      fill="currentColor"
+      d="M11.962 20q-3.046 0-5.311-1.99q-2.264-1.989-2.62-5.01h1.011q.408 2.58 2.351 4.29T11.962 19q2.925 0 4.962-2.037T18.962 12t-2.038-4.963T11.962 5q-1.553 0-2.918.656q-1.365.655-2.41 1.805h2.481v1H4.962V4.309h1v2.388q1.16-1.273 2.718-1.984T11.962 4q1.663 0 3.118.626t2.542 1.714t1.714 2.542t.626 3.118t-.626 3.118t-1.714 2.542t-2.542 1.714t-3.118.626m3.204-4.146l-3.647-3.646V7h1v4.792l3.354 3.354z"
+    />
+  </svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: "MaterialSymbolsLightHistory",
+};
+</script>

--- a/resources/client/components/ui/button/index.ts
+++ b/resources/client/components/ui/button/index.ts
@@ -15,8 +15,6 @@ export const buttonVariants = cva(
           "border border-brand-maroon-800/20 hover:bg-white brand-maroon-800/20 hover:text-brand-maroon-800 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
         secondary:
           "bg-brand-maroon-800/5 text-brand-maroon-800 hover:bg-brand-maroon-800/80 hover:text-white dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80",
-        tertiary:
-          "bg-brand-maroon-800/5 text-brand-maroon-800 hover:bg-brand-maroon-800/80 hover:text-white dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80 uppercase text-[0.6rem] font-semibold",
         ghost:
           "hover:bg-neutral-100 hover:text-brand-maroon-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
         link: "text-brand-maroon-800 underline-offset-4 hover:underline dark:text-neutral-50",

--- a/resources/client/components/ui/button/index.ts
+++ b/resources/client/components/ui/button/index.ts
@@ -15,6 +15,8 @@ export const buttonVariants = cva(
           "border border-brand-maroon-800/20 hover:bg-white brand-maroon-800/20 hover:text-brand-maroon-800 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
         secondary:
           "bg-brand-maroon-800/5 text-brand-maroon-800 hover:bg-brand-maroon-800/80 hover:text-white dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80",
+        tertiary:
+          "bg-brand-maroon-800/5 text-brand-maroon-800 hover:bg-brand-maroon-800/80 hover:text-white dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80 uppercase text-[0.6rem] font-semibold",
         ghost:
           "hover:bg-neutral-100 hover:text-brand-maroon-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
         link: "text-brand-maroon-800 underline-offset-4 hover:underline dark:text-neutral-50",

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditEventBadge.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditEventBadge.vue
@@ -1,0 +1,47 @@
+<template>
+  <Badge :variant="variant" :class="badgeClass">
+    {{ label }}
+  </Badge>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { Badge } from "@/components/ui/badge";
+import type { AuditEvent } from "@/types";
+
+const props = defineProps<{
+  event: AuditEvent;
+}>();
+
+const variant = computed(() => "outline" as const);
+
+const badgeClass = computed(() => {
+  switch (props.event) {
+    case "created":
+      return "border-green-200 bg-green-100 text-green-700";
+    case "updated":
+      return "border-blue-200 bg-blue-100 text-blue-700";
+    case "deleted":
+      return "border-red-200 bg-red-100 text-red-700";
+    case "restored":
+      return "border-amber-200 bg-amber-100 text-amber-700";
+    default:
+      return "";
+  }
+});
+
+const label = computed(() => {
+  switch (props.event) {
+    case "created":
+      return "Created";
+    case "updated":
+      return "Updated";
+    case "deleted":
+      return "Deleted";
+    case "restored":
+      return "Restored";
+    default:
+      return props.event;
+  }
+});
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditTimelineItem.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditTimelineItem.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="border rounded-lg bg-white overflow-hidden">
+    <button
+      type="button"
+      class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 transition-colors"
+      @click="isExpanded = !isExpanded"
+    >
+      <div class="flex items-center gap-3">
+        <AuditEventBadge :event="audit.event" />
+        <div>
+          <p class="font-medium text-brand-maroon-900">
+            {{ auditDescription }}
+          </p>
+          <p class="text-sm text-brand-maroon-900/60">
+            {{ audit.user?.name ?? "System" }} &middot;
+            {{ formatDate(audit.created_at) }}
+          </p>
+        </div>
+      </div>
+      <ChevronDownIcon
+        class="size-5 text-brand-maroon-900/50 transition-transform"
+        :class="{ 'rotate-180': isExpanded }"
+      />
+    </button>
+
+    <div v-if="isExpanded" class="px-4 pb-4 border-t bg-gray-50">
+      <AuditValuesDiff
+        :old-values="audit.old_values"
+        :new-values="audit.new_values"
+        :auditable-type="audit.auditable_type"
+        :event="audit.event"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import type { AuditRecord } from "@/types";
+import { ChevronDownIcon } from "@radix-icons/vue";
+import AuditEventBadge from "./AuditEventBadge.vue";
+import AuditValuesDiff from "./AuditValuesDiff.vue";
+
+const props = defineProps<{
+  audit: AuditRecord;
+}>();
+
+const isExpanded = ref(false);
+
+const auditDescription = computed(() => {
+  const type = props.audit.auditable_type.toLowerCase();
+  const event = props.audit.event;
+
+  const eventLabels: Record<string, string> = {
+    created: "created",
+    updated: "updated",
+    deleted: "deleted",
+    restored: "restored",
+  };
+
+  return `${type.charAt(0).toUpperCase() + type.slice(1)} ${eventLabels[event] ?? event}`;
+});
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString();
+}
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
@@ -10,11 +10,17 @@
       </p>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div v-if="showOldValue">
+        <div>
           <p class="text-xs text-brand-maroon-900/50 mb-1">Before</p>
-          <div class="p-3 bg-red-50 border border-red-200 rounded text-sm">
+          <div
+            class="p-3 rounded text-sm"
+            :class="hasOldValue ? 'bg-red-50 border border-red-200' : 'bg-gray-100 border border-gray-200'"
+          >
+            <span v-if="!hasOldValue" class="text-brand-maroon-900/40 italic">
+              N/A
+            </span>
             <CardContentPreview
-              v-if="isCardContentField(field)"
+              v-else-if="isCardContentField(field)"
               :blocks="parseCardContent(oldValues?.[field])"
             />
             <span v-else class="whitespace-pre-wrap break-words">{{
@@ -23,11 +29,17 @@
           </div>
         </div>
 
-        <div v-if="showNewValue">
+        <div>
           <p class="text-xs text-brand-maroon-900/50 mb-1">After</p>
-          <div class="p-3 bg-green-50 border border-green-200 rounded text-sm">
+          <div
+            class="p-3 rounded text-sm"
+            :class="hasNewValue ? 'bg-green-50 border border-green-200' : 'bg-gray-100 border border-gray-200'"
+          >
+            <span v-if="!hasNewValue" class="text-brand-maroon-900/40 italic">
+              N/A
+            </span>
             <CardContentPreview
-              v-if="isCardContentField(field)"
+              v-else-if="isCardContentField(field)"
               :blocks="parseCardContent(newValues?.[field])"
             />
             <span v-else class="whitespace-pre-wrap break-words">{{
@@ -52,8 +64,9 @@ const props = defineProps<{
   event: AuditEvent;
 }>();
 
-const showOldValue = computed(() => props.event !== "created");
-const showNewValue = computed(() => props.event !== "deleted");
+// For "created" events, there's no old value; for "deleted" events, there's no new value
+const hasOldValue = computed(() => props.event !== "created");
+const hasNewValue = computed(() => props.event !== "deleted");
 
 const changedFields = computed(() => {
   const allFields = new Set([

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="mt-4 space-y-4">
+    <div v-if="changedFields.length === 0" class="text-sm text-brand-maroon-900/50">
+      No field changes recorded.
+    </div>
+
+    <div v-for="field in changedFields" :key="field" class="space-y-2">
+      <p class="text-xs font-semibold text-brand-maroon-900/70 uppercase tracking-wide">
+        {{ formatFieldName(field) }}
+      </p>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div v-if="showOldValue">
+          <p class="text-xs text-brand-maroon-900/50 mb-1">Before</p>
+          <div class="p-3 bg-red-50 border border-red-200 rounded text-sm">
+            <CardContentPreview
+              v-if="isCardContentField(field)"
+              :blocks="parseCardContent(oldValues?.[field])"
+            />
+            <span v-else class="whitespace-pre-wrap break-words">{{
+              formatValue(oldValues?.[field])
+            }}</span>
+          </div>
+        </div>
+
+        <div v-if="showNewValue">
+          <p class="text-xs text-brand-maroon-900/50 mb-1">After</p>
+          <div class="p-3 bg-green-50 border border-green-200 rounded text-sm">
+            <CardContentPreview
+              v-if="isCardContentField(field)"
+              :blocks="parseCardContent(newValues?.[field])"
+            />
+            <span v-else class="whitespace-pre-wrap break-words">{{
+              formatValue(newValues?.[field])
+            }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { AuditableType, AuditEvent, ContentBlock } from "@/types";
+import CardContentPreview from "./CardContentPreview.vue";
+
+const props = defineProps<{
+  oldValues: Record<string, unknown> | null;
+  newValues: Record<string, unknown> | null;
+  auditableType: AuditableType;
+  event: AuditEvent;
+}>();
+
+const showOldValue = computed(() => props.event !== "created");
+const showNewValue = computed(() => props.event !== "deleted");
+
+const changedFields = computed(() => {
+  const allFields = new Set([
+    ...Object.keys(props.oldValues ?? {}),
+    ...Object.keys(props.newValues ?? {}),
+  ]);
+  return Array.from(allFields).filter((field) => !isIgnoredField(field));
+});
+
+function isIgnoredField(field: string): boolean {
+  // Skip internal/technical fields that aren't meaningful to users
+  const ignoredFields = ["id", "deck_id", "created_at", "updated_at", "deleted_at"];
+  return ignoredFields.includes(field);
+}
+
+function formatFieldName(field: string): string {
+  return field
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function isCardContentField(field: string): boolean {
+  return props.auditableType === "Card" && (field === "front" || field === "back");
+}
+
+function parseCardContent(value: unknown): ContentBlock[] {
+  if (!value) {
+    return [];
+  }
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as ContentBlock[];
+    } catch {
+      return [];
+    }
+  }
+  if (Array.isArray(value)) {
+    return value as ContentBlock[];
+  }
+  return [];
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "(empty)";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value, null, 2);
+  }
+  return String(value);
+}
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-4 space-y-4">
+  <div class="mt-4">
     <div
       v-if="changedFields.length === 0"
       class="text-sm text-brand-maroon-900/50"
@@ -7,60 +7,83 @@
       No field changes recorded.
     </div>
 
-    <div v-for="field in changedFields" :key="field" class="space-y-2">
-      <p
-        class="text-xs font-semibold text-brand-maroon-900/70 uppercase tracking-wide"
+    <div v-else class="grid grid-cols-1 md:grid-cols-[auto_1fr_1fr]">
+      <!-- Header row (hidden on mobile) -->
+      <div
+        class="hidden md:contents text-xs font-semibold text-brand-maroon-900/70 uppercase tracking-wide"
       >
-        {{ formatFieldName(field) }}
-      </p>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div>
-          <p class="text-xs text-brand-maroon-900/50 mb-1">Before</p>
-          <div
-            class="p-3 rounded text-sm"
-            :class="
-              hasOldValue
-                ? 'bg-red-50 border border-red-200'
-                : 'bg-neutral-100 border border-neutral-200'
-            "
-          >
-            <span v-if="!hasOldValue" class="text-brand-maroon-900/40 italic">
-              N/A
-            </span>
-            <CardContentPreview
-              v-else-if="isCardContentField(field)"
-              :blocks="parseCardContent(oldValues?.[field])"
-            />
-            <span v-else class="whitespace-pre-wrap break-words">{{
-              formatValue(oldValues?.[field])
-            }}</span>
-          </div>
-        </div>
-
-        <div>
-          <p class="text-xs text-brand-maroon-900/50 mb-1">After</p>
-          <div
-            class="p-3 rounded text-sm"
-            :class="
-              hasNewValue
-                ? 'bg-green-50 border border-green-200'
-                : 'bg-gray-100 border border-gray-200'
-            "
-          >
-            <span v-if="!hasNewValue" class="text-brand-maroon-900/40 italic">
-              N/A
-            </span>
-            <CardContentPreview
-              v-else-if="isCardContentField(field)"
-              :blocks="parseCardContent(newValues?.[field])"
-            />
-            <span v-else class="whitespace-pre-wrap break-words">{{
-              formatValue(newValues?.[field])
-            }}</span>
-          </div>
-        </div>
+        <div class="p-2">Field</div>
+        <div class="p-2">Before</div>
+        <div class="p-2">After</div>
       </div>
+
+      <!-- Data rows -->
+      <template v-for="field in changedFields" :key="field">
+        <div
+          class="md:contents border-t border-brand-maroon-900/10 pt-3 md:pt-0 md:border-0 first:border-0 first:pt-0"
+        >
+          <!-- Field name -->
+          <div
+            class="py-1 md:py-3 text-sm font-medium text-brand-maroon-900/70 md:border-t md:border-brand-maroon-900/10 px-3"
+          >
+            {{ formatFieldName(field) }}
+          </div>
+
+          <!-- Before value -->
+          <div
+            class="py-1 md:py-3 md:border-t md:border-brand-maroon-900/10 px-3"
+          >
+            <p class="text-xs text-brand-maroon-900/50 mb-1 md:hidden">
+              Before
+            </p>
+            <div
+              class="p-3 rounded text-sm"
+              :class="
+                hasOldValue
+                  ? 'bg-red-50 border border-red-200'
+                  : 'bg-neutral-100 border border-neutral-200'
+              "
+            >
+              <span v-if="!hasOldValue" class="text-brand-maroon-900/40 italic">
+                N/A
+              </span>
+              <CardContentPreview
+                v-else-if="isCardContentField(field)"
+                :blocks="parseCardContent(oldValues?.[field])"
+              />
+              <span v-else class="whitespace-pre-wrap break-words">{{
+                formatValue(oldValues?.[field])
+              }}</span>
+            </div>
+          </div>
+
+          <!-- After value -->
+          <div
+            class="py-1 md:py-3 md:border-t md:border-brand-maroon-900/10 px-3"
+          >
+            <p class="text-xs text-brand-maroon-900/50 mb-1 md:hidden">After</p>
+            <div
+              class="p-3 rounded text-sm"
+              :class="
+                hasNewValue
+                  ? 'bg-green-50 border border-green-200'
+                  : 'bg-gray-100 border border-gray-200'
+              "
+            >
+              <span v-if="!hasNewValue" class="text-brand-maroon-900/40 italic">
+                N/A
+              </span>
+              <CardContentPreview
+                v-else-if="isCardContentField(field)"
+                :blocks="parseCardContent(newValues?.[field])"
+              />
+              <span v-else class="whitespace-pre-wrap break-words">{{
+                formatValue(newValues?.[field])
+              }}</span>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/AuditValuesDiff.vue
@@ -1,11 +1,16 @@
 <template>
   <div class="mt-4 space-y-4">
-    <div v-if="changedFields.length === 0" class="text-sm text-brand-maroon-900/50">
+    <div
+      v-if="changedFields.length === 0"
+      class="text-sm text-brand-maroon-900/50"
+    >
       No field changes recorded.
     </div>
 
     <div v-for="field in changedFields" :key="field" class="space-y-2">
-      <p class="text-xs font-semibold text-brand-maroon-900/70 uppercase tracking-wide">
+      <p
+        class="text-xs font-semibold text-brand-maroon-900/70 uppercase tracking-wide"
+      >
         {{ formatFieldName(field) }}
       </p>
 
@@ -14,7 +19,11 @@
           <p class="text-xs text-brand-maroon-900/50 mb-1">Before</p>
           <div
             class="p-3 rounded text-sm"
-            :class="hasOldValue ? 'bg-red-50 border border-red-200' : 'bg-gray-100 border border-gray-200'"
+            :class="
+              hasOldValue
+                ? 'bg-red-50 border border-red-200'
+                : 'bg-neutral-100 border border-neutral-200'
+            "
           >
             <span v-if="!hasOldValue" class="text-brand-maroon-900/40 italic">
               N/A
@@ -33,7 +42,11 @@
           <p class="text-xs text-brand-maroon-900/50 mb-1">After</p>
           <div
             class="p-3 rounded text-sm"
-            :class="hasNewValue ? 'bg-green-50 border border-green-200' : 'bg-gray-100 border border-gray-200'"
+            :class="
+              hasNewValue
+                ? 'bg-green-50 border border-green-200'
+                : 'bg-gray-100 border border-gray-200'
+            "
           >
             <span v-if="!hasNewValue" class="text-brand-maroon-900/40 italic">
               N/A
@@ -78,7 +91,13 @@ const changedFields = computed(() => {
 
 function isIgnoredField(field: string): boolean {
   // Skip internal/technical fields that aren't meaningful to users
-  const ignoredFields = ["id", "deck_id", "created_at", "updated_at", "deleted_at"];
+  const ignoredFields = [
+    "id",
+    "deck_id",
+    "created_at",
+    "updated_at",
+    "deleted_at",
+  ];
   return ignoredFields.includes(field);
 }
 
@@ -89,7 +108,9 @@ function formatFieldName(field: string): string {
 }
 
 function isCardContentField(field: string): boolean {
-  return props.auditableType === "Card" && (field === "front" || field === "back");
+  return (
+    props.auditableType === "Card" && (field === "front" || field === "back")
+  );
 }
 
 function parseCardContent(value: unknown): ContentBlock[] {

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
@@ -9,7 +9,7 @@
       class="flex items-start gap-2"
     >
       <span
-        class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded bg-brand-maroon-900/10 text-brand-maroon-900/70"
+        class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded bg-white shadow-sm text-brand-maroon-900/70"
       >
         {{ formatBlockType(block.type) }}
       </span>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
@@ -1,58 +1,27 @@
 <template>
-  <div class="space-y-2">
-    <div v-if="blocks.length === 0" class="text-brand-maroon-900/50 italic">
-      (empty)
-    </div>
-    <div
-      v-for="(block, index) in blocks"
-      :key="block.id ?? index"
-      class="flex items-start gap-2"
-    >
-      <span
-        class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded bg-white shadow-sm text-brand-maroon-900/70"
-      >
-        {{ formatBlockType(block.type) }}
-      </span>
-      <span class="flex-1 break-words">{{ getBlockPreview(block) }}</span>
-    </div>
+  <div v-if="blocks.length === 0" class="text-brand-maroon-900/50 italic">
+    (empty)
   </div>
+  <CardSideView
+    v-else
+    :side="blocks"
+    :side-name="sideName"
+    :show-label="false"
+    class="text-sm overflow-auto bg-white mx-auto w-48 h-64"
+  />
 </template>
 
 <script setup lang="ts">
-import type { ContentBlock } from "@/types";
+import type { CardSide, CardSideName } from "@/types";
+import CardSideView from "@/components/CardSideView/CardSideView.vue";
 
-defineProps<{
-  blocks: ContentBlock[];
-}>();
-
-function formatBlockType(type: string): string {
-  return type.charAt(0).toUpperCase() + type.slice(1);
-}
-
-function getBlockPreview(block: ContentBlock): string {
-  switch (block.type) {
-    case "text":
-      return stripHtml(String(block.content || ""));
-    case "image":
-      return block.meta?.alt ? `Image: ${block.meta.alt}` : "Image";
-    case "audio":
-      return "Audio file";
-    case "video":
-      return "Video";
-    case "embed":
-      return `Embed: ${block.content}`;
-    case "hint":
-      return `Hint: ${block.content}`;
-    case "math":
-      return `Math: ${block.content}`;
-    default:
-      return JSON.stringify(block.content);
-  }
-}
-
-function stripHtml(html: string): string {
-  const tmp = document.createElement("div");
-  tmp.innerHTML = html;
-  return tmp.textContent || tmp.innerText || "";
-}
+withDefaults(
+  defineProps<{
+    blocks: CardSide;
+    sideName?: CardSideName;
+  }>(),
+  {
+    sideName: "front",
+  },
+);
 </script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/CardContentPreview.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="space-y-2">
+    <div v-if="blocks.length === 0" class="text-brand-maroon-900/50 italic">
+      (empty)
+    </div>
+    <div
+      v-for="(block, index) in blocks"
+      :key="block.id ?? index"
+      class="flex items-start gap-2"
+    >
+      <span
+        class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded bg-brand-maroon-900/10 text-brand-maroon-900/70"
+      >
+        {{ formatBlockType(block.type) }}
+      </span>
+      <span class="flex-1 break-words">{{ getBlockPreview(block) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ContentBlock } from "@/types";
+
+defineProps<{
+  blocks: ContentBlock[];
+}>();
+
+function formatBlockType(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function getBlockPreview(block: ContentBlock): string {
+  switch (block.type) {
+    case "text":
+      return stripHtml(String(block.content || ""));
+    case "image":
+      return block.meta?.alt ? `Image: ${block.meta.alt}` : "Image";
+    case "audio":
+      return "Audio file";
+    case "video":
+      return "Video";
+    case "embed":
+      return `Embed: ${block.content}`;
+    case "hint":
+      return `Hint: ${block.content}`;
+    case "math":
+      return `Math: ${block.content}`;
+    default:
+      return JSON.stringify(block.content);
+  }
+}
+
+function stripHtml(html: string): string {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  return tmp.textContent || tmp.innerText || "";
+}
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
@@ -16,16 +16,169 @@
           </div>
         </PageHeader>
 
-        <div v-if="auditHistory && auditHistory.data.length > 0" class="space-y-4">
-          <AuditTimelineItem
-            v-for="audit in auditHistory.data"
-            :key="audit.id"
-            :audit="audit"
-          />
+        <div v-if="auditHistory">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead class="w-8"></TableHead>
+                <TableHead>
+                  <SortableHeader
+                    label="Object"
+                    field="auditable_type"
+                    :current-sort="sortField"
+                    :current-direction="sortDirection"
+                    @sort="handleSort"
+                  />
+                </TableHead>
+                <TableHead>
+                  <SortableHeader
+                    label="Action"
+                    field="event"
+                    :current-sort="sortField"
+                    :current-direction="sortDirection"
+                    @sort="handleSort"
+                  />
+                </TableHead>
+                <TableHead>
+                  <SortableHeader
+                    label="User"
+                    field="user"
+                    :current-sort="sortField"
+                    :current-direction="sortDirection"
+                    @sort="handleSort"
+                  />
+                </TableHead>
+                <TableHead>
+                  <SortableHeader
+                    label="Date & Time"
+                    field="created_at"
+                    :current-sort="sortField"
+                    :current-direction="sortDirection"
+                    @sort="handleSort"
+                  />
+                </TableHead>
+              </TableRow>
+              <!-- Filter row -->
+              <TableRow class="bg-gray-50">
+                <TableHead class="w-8 py-2">
+                  <button
+                    v-if="hasActiveFilters"
+                    class="text-xs text-brand-teal-600 hover:text-brand-teal-700"
+                    title="Clear filters"
+                    @click="clearFilters"
+                  >
+                    Clear
+                  </button>
+                </TableHead>
+                <TableHead class="py-2">
+                  <select
+                    v-model="filterObject"
+                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                  >
+                    <option value="">All</option>
+                    <option value="Deck">Deck</option>
+                    <option value="Card">Card</option>
+                  </select>
+                </TableHead>
+                <TableHead class="py-2">
+                  <select
+                    v-model="filterAction"
+                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                  >
+                    <option value="">All</option>
+                    <option value="created">Created</option>
+                    <option value="updated">Updated</option>
+                    <option value="deleted">Deleted</option>
+                    <option value="restored">Restored</option>
+                  </select>
+                </TableHead>
+                <TableHead class="py-2">
+                  <input
+                    v-model="filterUser"
+                    type="text"
+                    placeholder="Filter..."
+                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                  />
+                </TableHead>
+                <TableHead class="py-2">
+                  <div class="flex gap-1 items-center">
+                    <input
+                      v-model="filterDateFrom"
+                      type="date"
+                      class="text-xs border border-brand-maroon-900/20 rounded px-1 py-1 bg-white"
+                      title="From date"
+                    />
+                    <span class="text-brand-maroon-900/40">-</span>
+                    <input
+                      v-model="filterDateTo"
+                      type="date"
+                      class="text-xs border border-brand-maroon-900/20 rounded px-1 py-1 bg-white"
+                      title="To date"
+                    />
+                  </div>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <!-- Empty state -->
+              <TableRow v-if="filteredAudits.length === 0">
+                <TableCell colspan="5" class="text-center py-8 text-brand-maroon-900/50">
+                  <p v-if="hasActiveFilters">No changes match the current filters.</p>
+                  <p v-else>No edit history found for this deck.</p>
+                </TableCell>
+              </TableRow>
+              <!-- Data rows -->
+              <template v-for="audit in sortedAudits" :key="audit.id">
+                <TableRow
+                  class="cursor-pointer hover:bg-brand-oatmeal-50"
+                  @click="toggleRow(audit.id)"
+                >
+                  <TableCell class="w-8">
+                    <ChevronDownIcon
+                      class="size-4 text-brand-maroon-900/50 transition-transform"
+                      :class="{ 'rotate-180': expandedRows.has(audit.id) }"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      :class="audit.auditable_type === 'Deck'
+                        ? 'bg-purple-100 text-purple-700'
+                        : 'bg-blue-100 text-blue-700'"
+                    >
+                      {{ audit.auditable_type }}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <AuditEventBadge :event="audit.event" />
+                  </TableCell>
+                  <TableCell>
+                    {{ audit.user?.name ?? "System" }}
+                  </TableCell>
+                  <TableCell class="text-brand-maroon-900/70">
+                    {{ formatDateTime(audit.created_at) }}
+                  </TableCell>
+                </TableRow>
+                <TableRow v-if="expandedRows.has(audit.id)">
+                  <TableCell colspan="5" class="bg-gray-50 p-0">
+                    <div class="px-6 py-4">
+                      <AuditValuesDiff
+                        :old-values="audit.old_values"
+                        :new-values="audit.new_values"
+                        :auditable-type="audit.auditable_type"
+                        :event="audit.event"
+                      />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              </template>
+            </TableBody>
+          </Table>
 
+          <!-- Pagination -->
           <div
             v-if="auditHistory.meta.last_page > 1"
-            class="mt-8 flex items-center justify-center gap-4"
+            class="mt-6 flex items-center justify-center gap-4"
           >
             <Button
               variant="outline"
@@ -47,13 +200,6 @@
             </Button>
           </div>
         </div>
-
-        <div
-          v-else-if="auditHistory"
-          class="text-center py-12 text-brand-maroon-900/50"
-        >
-          <p>No edit history found for this deck.</p>
-        </div>
       </DeckContextProvider>
     </div>
   </AuthenticatedLayout>
@@ -66,9 +212,21 @@ import { useDeckByIdQuery } from "@/queries/decks";
 import { useDeckAuditHistoryQuery } from "@/queries/decks/useDeckAuditHistoryQuery";
 import { computed, ref } from "vue";
 import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import Tuple from "@/components/Tuple.vue";
 import DeckContextProvider from "@/components/DeckContextProvider.vue";
-import AuditTimelineItem from "./AuditTimelineItem.vue";
+import AuditEventBadge from "./AuditEventBadge.vue";
+import AuditValuesDiff from "./AuditValuesDiff.vue";
+import SortableHeader from "./SortableHeader.vue";
+import { ChevronDownIcon } from "@radix-icons/vue";
+import type { AuditRecord, AuditEvent, AuditableType } from "@/types";
 
 const props = defineProps<{
   deckId: number;
@@ -79,4 +237,136 @@ const page = ref(1);
 
 const { data: deck } = useDeckByIdQuery(deckIdRef);
 const { data: auditHistory } = useDeckAuditHistoryQuery(deckIdRef, page);
+
+// Filters
+const filterObject = ref<AuditableType | "">("");
+const filterAction = ref<AuditEvent | "">("");
+const filterUser = ref("");
+const filterDateFrom = ref("");
+const filterDateTo = ref("");
+
+const hasActiveFilters = computed(() =>
+  Boolean(
+    filterObject.value ||
+    filterAction.value ||
+    filterUser.value ||
+    filterDateFrom.value ||
+    filterDateTo.value
+  )
+);
+
+function clearFilters() {
+  filterObject.value = "";
+  filterAction.value = "";
+  filterUser.value = "";
+  filterDateFrom.value = "";
+  filterDateTo.value = "";
+}
+
+// Sorting
+type SortField = "auditable_type" | "event" | "user" | "created_at";
+type SortDirection = "asc" | "desc";
+
+const sortField = ref<SortField>("created_at");
+const sortDirection = ref<SortDirection>("desc");
+
+function handleSort(field: string) {
+  const sortableField = field as SortField;
+  if (sortField.value === sortableField) {
+    sortDirection.value = sortDirection.value === "asc" ? "desc" : "asc";
+  } else {
+    sortField.value = sortableField;
+    sortDirection.value = "asc";
+  }
+}
+
+// Expandable rows
+const expandedRows = ref<Set<number>>(new Set());
+
+function toggleRow(id: number) {
+  if (expandedRows.value.has(id)) {
+    expandedRows.value.delete(id);
+  } else {
+    expandedRows.value.add(id);
+  }
+  // Trigger reactivity
+  expandedRows.value = new Set(expandedRows.value);
+}
+
+// Filtered audits
+const filteredAudits = computed((): AuditRecord[] => {
+  if (!auditHistory.value?.data) return [];
+
+  return auditHistory.value.data.filter((audit) => {
+    if (filterObject.value && audit.auditable_type !== filterObject.value) {
+      return false;
+    }
+    if (filterAction.value && audit.event !== filterAction.value) {
+      return false;
+    }
+    if (filterUser.value) {
+      const userName = audit.user?.name?.toLowerCase() ?? "";
+      if (!userName.includes(filterUser.value.toLowerCase())) {
+        return false;
+      }
+    }
+    if (filterDateFrom.value || filterDateTo.value) {
+      const auditDate = new Date(audit.created_at);
+      if (filterDateFrom.value) {
+        const fromDate = new Date(filterDateFrom.value);
+        fromDate.setHours(0, 0, 0, 0);
+        if (auditDate < fromDate) {
+          return false;
+        }
+      }
+      if (filterDateTo.value) {
+        const toDate = new Date(filterDateTo.value);
+        toDate.setHours(23, 59, 59, 999);
+        if (auditDate > toDate) {
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+});
+
+// Sorted audits
+const sortedAudits = computed((): AuditRecord[] => {
+  const audits = [...filteredAudits.value];
+
+  audits.sort((a, b) => {
+    let comparison = 0;
+
+    switch (sortField.value) {
+      case "auditable_type":
+        comparison = a.auditable_type.localeCompare(b.auditable_type);
+        break;
+      case "event":
+        comparison = a.event.localeCompare(b.event);
+        break;
+      case "user":
+        comparison = (a.user?.name ?? "").localeCompare(b.user?.name ?? "");
+        break;
+      case "created_at":
+        comparison = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+        break;
+    }
+
+    return sortDirection.value === "asc" ? comparison : -comparison;
+  });
+
+  return audits;
+});
+
+function formatDateTime(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 </script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
@@ -31,6 +31,9 @@
                   />
                 </TableHead>
                 <TableHead>
+                  <span class="text-brand-maroon-900/70">ID</span>
+                </TableHead>
+                <TableHead>
                   <SortableHeader
                     label="Action"
                     field="event"
@@ -81,6 +84,14 @@
                   </select>
                 </TableHead>
                 <TableHead class="py-2">
+                  <input
+                    v-model="filterId"
+                    type="text"
+                    placeholder="ID..."
+                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-16"
+                  />
+                </TableHead>
+                <TableHead class="py-2">
                   <select
                     v-model="filterAction"
                     class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
@@ -121,14 +132,14 @@
             </TableHeader>
             <TableBody>
               <!-- Empty state -->
-              <TableRow v-if="filteredAudits.length === 0">
-                <TableCell colspan="5" class="text-center py-8 text-brand-maroon-900/50">
+              <TableRow v-if="audits.length === 0">
+                <TableCell colspan="6" class="text-center py-8 text-brand-maroon-900/50">
                   <p v-if="hasActiveFilters">No changes match the current filters.</p>
                   <p v-else>No edit history found for this deck.</p>
                 </TableCell>
               </TableRow>
               <!-- Data rows -->
-              <template v-for="audit in sortedAudits" :key="audit.id">
+              <template v-for="audit in audits" :key="audit.id">
                 <TableRow
                   class="cursor-pointer hover:bg-brand-oatmeal-50"
                   @click="toggleRow(audit.id)"
@@ -149,6 +160,9 @@
                       {{ audit.auditable_type }}
                     </span>
                   </TableCell>
+                  <TableCell class="text-brand-maroon-900/70 font-mono text-sm">
+                    {{ audit.auditable_id }}
+                  </TableCell>
                   <TableCell>
                     <AuditEventBadge :event="audit.event" />
                   </TableCell>
@@ -160,7 +174,7 @@
                   </TableCell>
                 </TableRow>
                 <TableRow v-if="expandedRows.has(audit.id)">
-                  <TableCell colspan="5" class="bg-gray-50 p-0">
+                  <TableCell colspan="6" class="bg-gray-50 p-0">
                     <div class="px-6 py-4">
                       <AuditValuesDiff
                         :old-values="audit.old_values"
@@ -210,7 +224,7 @@ import PageHeader from "@/components/PageHeader.vue";
 import AuthenticatedLayout from "@/layouts/AuthenticatedLayout/AuthenticatedLayout.vue";
 import { useDeckByIdQuery } from "@/queries/decks";
 import { useDeckAuditHistoryQuery } from "@/queries/decks/useDeckAuditHistoryQuery";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -226,42 +240,21 @@ import AuditEventBadge from "./AuditEventBadge.vue";
 import AuditValuesDiff from "./AuditValuesDiff.vue";
 import SortableHeader from "./SortableHeader.vue";
 import { ChevronDownIcon } from "@radix-icons/vue";
-import type { AuditRecord, AuditEvent, AuditableType } from "@/types";
+import type { AuditEvent, AuditableType } from "@/types";
 
 const props = defineProps<{
   deckId: number;
 }>();
 
 const deckIdRef = computed(() => props.deckId);
-const page = ref(1);
-
-const { data: deck } = useDeckByIdQuery(deckIdRef);
-const { data: auditHistory } = useDeckAuditHistoryQuery(deckIdRef, page);
 
 // Filters
 const filterObject = ref<AuditableType | "">("");
+const filterId = ref("");
 const filterAction = ref<AuditEvent | "">("");
 const filterUser = ref("");
 const filterDateFrom = ref("");
 const filterDateTo = ref("");
-
-const hasActiveFilters = computed(() =>
-  Boolean(
-    filterObject.value ||
-    filterAction.value ||
-    filterUser.value ||
-    filterDateFrom.value ||
-    filterDateTo.value
-  )
-);
-
-function clearFilters() {
-  filterObject.value = "";
-  filterAction.value = "";
-  filterUser.value = "";
-  filterDateFrom.value = "";
-  filterDateTo.value = "";
-}
 
 // Sorting
 type SortField = "auditable_type" | "event" | "user" | "created_at";
@@ -269,6 +262,57 @@ type SortDirection = "asc" | "desc";
 
 const sortField = ref<SortField>("created_at");
 const sortDirection = ref<SortDirection>("desc");
+
+// Pagination
+const page = ref(1);
+
+// Build query params from filter/sort state
+const queryParams = computed(() => ({
+  page: page.value,
+  object: filterObject.value || undefined,
+  id: filterId.value || undefined,
+  action: filterAction.value || undefined,
+  user: filterUser.value || undefined,
+  from: filterDateFrom.value || undefined,
+  to: filterDateTo.value || undefined,
+  sort: sortField.value,
+  direction: sortDirection.value,
+}));
+
+// Reset to page 1 when filters or sort changes
+watch(
+  [filterObject, filterId, filterAction, filterUser, filterDateFrom, filterDateTo, sortField, sortDirection],
+  () => {
+    page.value = 1;
+  }
+);
+
+const { data: deck } = useDeckByIdQuery(deckIdRef);
+const { data: auditHistory } = useDeckAuditHistoryQuery(deckIdRef, queryParams);
+
+// Computed helpers
+const hasActiveFilters = computed(() =>
+  Boolean(
+    filterObject.value ||
+    filterId.value ||
+    filterAction.value ||
+    filterUser.value ||
+    filterDateFrom.value ||
+    filterDateTo.value
+  )
+);
+
+const audits = computed(() => auditHistory.value?.data ?? []);
+
+// Actions
+function clearFilters() {
+  filterObject.value = "";
+  filterId.value = "";
+  filterAction.value = "";
+  filterUser.value = "";
+  filterDateFrom.value = "";
+  filterDateTo.value = "";
+}
 
 function handleSort(field: string) {
   const sortableField = field as SortField;
@@ -292,72 +336,6 @@ function toggleRow(id: number) {
   // Trigger reactivity
   expandedRows.value = new Set(expandedRows.value);
 }
-
-// Filtered audits
-const filteredAudits = computed((): AuditRecord[] => {
-  if (!auditHistory.value?.data) return [];
-
-  return auditHistory.value.data.filter((audit) => {
-    if (filterObject.value && audit.auditable_type !== filterObject.value) {
-      return false;
-    }
-    if (filterAction.value && audit.event !== filterAction.value) {
-      return false;
-    }
-    if (filterUser.value) {
-      const userName = audit.user?.name?.toLowerCase() ?? "";
-      if (!userName.includes(filterUser.value.toLowerCase())) {
-        return false;
-      }
-    }
-    if (filterDateFrom.value || filterDateTo.value) {
-      const auditDate = new Date(audit.created_at);
-      if (filterDateFrom.value) {
-        const fromDate = new Date(filterDateFrom.value);
-        fromDate.setHours(0, 0, 0, 0);
-        if (auditDate < fromDate) {
-          return false;
-        }
-      }
-      if (filterDateTo.value) {
-        const toDate = new Date(filterDateTo.value);
-        toDate.setHours(23, 59, 59, 999);
-        if (auditDate > toDate) {
-          return false;
-        }
-      }
-    }
-    return true;
-  });
-});
-
-// Sorted audits
-const sortedAudits = computed((): AuditRecord[] => {
-  const audits = [...filteredAudits.value];
-
-  audits.sort((a, b) => {
-    let comparison = 0;
-
-    switch (sortField.value) {
-      case "auditable_type":
-        comparison = a.auditable_type.localeCompare(b.auditable_type);
-        break;
-      case "event":
-        comparison = a.event.localeCompare(b.event);
-        break;
-      case "user":
-        comparison = (a.user?.name ?? "").localeCompare(b.user?.name ?? "");
-        break;
-      case "created_at":
-        comparison = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-        break;
-    }
-
-    return sortDirection.value === "asc" ? comparison : -comparison;
-  });
-
-  return audits;
-});
 
 function formatDateTime(dateString: string): string {
   const date = new Date(dateString);

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
@@ -1,0 +1,82 @@
+<template>
+  <AuthenticatedLayout>
+    <div v-if="deck" class="max-w-screen-lg mx-auto">
+      <DeckContextProvider :deck="deck">
+        <PageHeader
+          title="Edit History"
+          :subtitle="deck?.name"
+          :backLabel="deck?.name"
+          :backTo="{ name: 'decks.show', params: { deckId } }"
+          class="mb-8"
+        >
+          <div class="flex justify-end gap-4">
+            <Tuple label="Total Changes">
+              {{ auditHistory?.meta.total ?? 0 }}
+            </Tuple>
+          </div>
+        </PageHeader>
+
+        <div v-if="auditHistory && auditHistory.data.length > 0" class="space-y-4">
+          <AuditTimelineItem
+            v-for="audit in auditHistory.data"
+            :key="audit.id"
+            :audit="audit"
+          />
+
+          <div
+            v-if="auditHistory.meta.last_page > 1"
+            class="mt-8 flex items-center justify-center gap-4"
+          >
+            <Button
+              variant="outline"
+              :disabled="!auditHistory.links.prev"
+              @click="page--"
+            >
+              Previous
+            </Button>
+            <span class="text-sm text-brand-maroon-900/70">
+              Page {{ auditHistory.meta.current_page }} of
+              {{ auditHistory.meta.last_page }}
+            </span>
+            <Button
+              variant="outline"
+              :disabled="!auditHistory.links.next"
+              @click="page++"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+
+        <div
+          v-else-if="auditHistory"
+          class="text-center py-12 text-brand-maroon-900/50"
+        >
+          <p>No edit history found for this deck.</p>
+        </div>
+      </DeckContextProvider>
+    </div>
+  </AuthenticatedLayout>
+</template>
+
+<script setup lang="ts">
+import PageHeader from "@/components/PageHeader.vue";
+import AuthenticatedLayout from "@/layouts/AuthenticatedLayout/AuthenticatedLayout.vue";
+import { useDeckByIdQuery } from "@/queries/decks";
+import { useDeckAuditHistoryQuery } from "@/queries/decks/useDeckAuditHistoryQuery";
+import { computed, ref } from "vue";
+import { Button } from "@/components/ui/button";
+import Tuple from "@/components/Tuple.vue";
+import DeckContextProvider from "@/components/DeckContextProvider.vue";
+import AuditTimelineItem from "./AuditTimelineItem.vue";
+
+const props = defineProps<{
+  deckId: number;
+}>();
+
+const deckIdRef = computed(() => props.deckId);
+const page = ref(1);
+
+const { data: deck } = useDeckByIdQuery(deckIdRef);
+const { data: auditHistory } = useDeckAuditHistoryQuery(deckIdRef, page);
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue
@@ -3,7 +3,7 @@
     <div v-if="deck" class="max-w-screen-lg mx-auto">
       <DeckContextProvider :deck="deck">
         <PageHeader
-          title="Edit History"
+          title="Deck History"
           :subtitle="deck?.name"
           :backLabel="deck?.name"
           :backTo="{ name: 'decks.show', params: { deckId } }"
@@ -16,10 +16,13 @@
           </div>
         </PageHeader>
 
-        <div v-if="auditHistory">
+        <div
+          v-if="auditHistory"
+          class="bg-brand-oatmeal-50 rounded-md shadow overflow-clip"
+        >
           <Table>
             <TableHeader>
-              <TableRow>
+              <TableRow class="bg-brand-maroon-900/10">
                 <TableHead class="w-8"></TableHead>
                 <TableHead>
                   <SortableHeader
@@ -31,7 +34,13 @@
                   />
                 </TableHead>
                 <TableHead>
-                  <span class="text-brand-maroon-900/70">ID</span>
+                  <SortableHeader
+                    label="Object ID"
+                    field="auditable_id"
+                    :current-sort="sortField"
+                    :current-direction="sortDirection"
+                    @sort="handleSort"
+                  />
                 </TableHead>
                 <TableHead>
                   <SortableHeader
@@ -62,21 +71,21 @@
                 </TableHead>
               </TableRow>
               <!-- Filter row -->
-              <TableRow class="bg-gray-50">
+              <TableRow>
                 <TableHead class="w-8 py-2">
-                  <button
+                  <Button
                     v-if="hasActiveFilters"
-                    class="text-xs text-brand-teal-600 hover:text-brand-teal-700"
                     title="Clear filters"
                     @click="clearFilters"
+                    class="uppercase text-[0.66rem] px-2 py-0.5 font-semibold rounded"
                   >
                     Clear
-                  </button>
+                  </Button>
                 </TableHead>
                 <TableHead class="py-2">
                   <select
                     v-model="filterObject"
-                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                    class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 w-20 font-medium"
                   >
                     <option value="">All</option>
                     <option value="Deck">Deck</option>
@@ -88,13 +97,13 @@
                     v-model="filterId"
                     type="text"
                     placeholder="ID..."
-                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-16"
+                    class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 w-16 placeholder:text-black/25"
                   />
                 </TableHead>
                 <TableHead class="py-2">
                   <select
                     v-model="filterAction"
-                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                    class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 font-medium w-full"
                   >
                     <option value="">All</option>
                     <option value="created">Created</option>
@@ -108,7 +117,7 @@
                     v-model="filterUser"
                     type="text"
                     placeholder="Filter..."
-                    class="text-xs border border-brand-maroon-900/20 rounded px-1.5 py-1 bg-white w-full"
+                    class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 placeholder:text-black/25 w-full"
                   />
                 </TableHead>
                 <TableHead class="py-2">
@@ -116,14 +125,14 @@
                     <input
                       v-model="filterDateFrom"
                       type="date"
-                      class="text-xs border border-brand-maroon-900/20 rounded px-1 py-1 bg-white"
+                      class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 placeholder:text-black/25 w-28 font-medium"
                       title="From date"
                     />
                     <span class="text-brand-maroon-900/40">-</span>
                     <input
                       v-model="filterDateTo"
                       type="date"
-                      class="text-xs border border-brand-maroon-900/20 rounded px-1 py-1 bg-white"
+                      class="text-xs border-none rounded px-1.5 py-1 bg-brand-maroon-900/5 placeholder:text-black/25 w-28 font-medium"
                       title="To date"
                     />
                   </div>
@@ -133,8 +142,13 @@
             <TableBody>
               <!-- Empty state -->
               <TableRow v-if="audits.length === 0">
-                <TableCell colspan="6" class="text-center py-8 text-brand-maroon-900/50">
-                  <p v-if="hasActiveFilters">No changes match the current filters.</p>
+                <TableCell
+                  colspan="6"
+                  class="text-center py-8 text-brand-maroon-900/50"
+                >
+                  <p v-if="hasActiveFilters">
+                    No changes match the current filters.
+                  </p>
                   <p v-else>No edit history found for this deck.</p>
                 </TableCell>
               </TableRow>
@@ -153,9 +167,11 @@
                   <TableCell>
                     <span
                       class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-                      :class="audit.auditable_type === 'Deck'
-                        ? 'bg-purple-100 text-purple-700'
-                        : 'bg-blue-100 text-blue-700'"
+                      :class="
+                        audit.auditable_type === 'Deck'
+                          ? 'bg-purple-100 text-purple-700'
+                          : 'bg-blue-100 text-blue-700'
+                      "
                     >
                       {{ audit.auditable_type }}
                     </span>
@@ -174,7 +190,7 @@
                   </TableCell>
                 </TableRow>
                 <TableRow v-if="expandedRows.has(audit.id)">
-                  <TableCell colspan="6" class="bg-gray-50 p-0">
+                  <TableCell colspan="6" class="bg-white p-0">
                     <div class="px-6 py-4">
                       <AuditValuesDiff
                         :old-values="audit.old_values"
@@ -281,10 +297,19 @@ const queryParams = computed(() => ({
 
 // Reset to page 1 when filters or sort changes
 watch(
-  [filterObject, filterId, filterAction, filterUser, filterDateFrom, filterDateTo, sortField, sortDirection],
+  [
+    filterObject,
+    filterId,
+    filterAction,
+    filterUser,
+    filterDateFrom,
+    filterDateTo,
+    sortField,
+    sortDirection,
+  ],
   () => {
     page.value = 1;
-  }
+  },
 );
 
 const { data: deck } = useDeckByIdQuery(deckIdRef);
@@ -298,8 +323,8 @@ const hasActiveFilters = computed(() =>
     filterAction.value ||
     filterUser.value ||
     filterDateFrom.value ||
-    filterDateTo.value
-  )
+    filterDateTo.value,
+  ),
 );
 
 const audits = computed(() => auditHistory.value?.data ?? []);

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
@@ -5,18 +5,18 @@
     @click="$emit('sort', field)"
   >
     <span>{{ label }}</span>
-    <span class="flex flex-col">
-      <ChevronUpIcon
-        class="size-3 -mb-1"
-        :class="isActive && currentDirection === 'asc'
-          ? 'text-brand-teal-600'
-          : 'text-brand-maroon-900/30'"
+    <span class="flex flex-col text-brand-maroon-900">
+      <CaretUpIcon
+        class="size-4"
+        :class="isActive && currentDirection === 'asc' ? 'block' : 'hidden'"
       />
-      <ChevronDownIcon
-        class="size-3"
-        :class="isActive && currentDirection === 'desc'
-          ? 'text-brand-teal-600'
-          : 'text-brand-maroon-900/30'"
+      <CaretDownIcon
+        class="size-4"
+        :class="isActive && currentDirection === 'desc' ? 'block' : 'hidden'"
+      />
+      <CaretSortIcon
+        class="size-4 text-brand-maroon-900/30"
+        :class="!isActive ? 'block' : 'hidden'"
       />
     </span>
   </button>
@@ -24,7 +24,13 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { ChevronUpIcon, ChevronDownIcon } from "@radix-icons/vue";
+import {
+  ChevronUpIcon,
+  ChevronDownIcon,
+  CaretSortIcon,
+  CaretDownIcon,
+  CaretUpIcon,
+} from "@radix-icons/vue";
 
 const props = defineProps<{
   label: string;

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
@@ -1,0 +1,41 @@
+<template>
+  <button
+    type="button"
+    class="flex items-center gap-1 hover:text-brand-maroon-900 transition-colors"
+    @click="$emit('sort', field)"
+  >
+    <span>{{ label }}</span>
+    <span class="flex flex-col">
+      <ChevronUpIcon
+        class="size-3 -mb-1"
+        :class="isActive && currentDirection === 'asc'
+          ? 'text-brand-teal-600'
+          : 'text-brand-maroon-900/30'"
+      />
+      <ChevronDownIcon
+        class="size-3"
+        :class="isActive && currentDirection === 'desc'
+          ? 'text-brand-teal-600'
+          : 'text-brand-maroon-900/30'"
+      />
+    </span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { ChevronUpIcon, ChevronDownIcon } from "@radix-icons/vue";
+
+const props = defineProps<{
+  label: string;
+  field: string;
+  currentSort: string;
+  currentDirection: "asc" | "desc";
+}>();
+
+defineEmits<{
+  sort: [field: string];
+}>();
+
+const isActive = computed(() => props.currentSort === props.field);
+</script>

--- a/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
+++ b/resources/client/pages/Decks/DeckAuditHistoryPage/SortableHeader.vue
@@ -24,13 +24,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import {
-  ChevronUpIcon,
-  ChevronDownIcon,
-  CaretSortIcon,
-  CaretDownIcon,
-  CaretUpIcon,
-} from "@radix-icons/vue";
+import { CaretSortIcon, CaretDownIcon, CaretUpIcon } from "@radix-icons/vue";
 
 const props = defineProps<{
   label: string;

--- a/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
@@ -13,6 +13,17 @@
           Settings
         </RouterLink>
       </DropdownMenuItem>
+      <DropdownMenuItem asChild v-if="deck.capabilities.canViewAuditHistory">
+        <RouterLink
+          :to="{
+            name: 'decks.reports.auditHistory',
+            params: { deckId: deck.id },
+          }"
+        >
+          <IconHistory class="size-5 mr-4" />
+          History
+        </RouterLink>
+      </DropdownMenuItem>
       <DropdownMenuItem asChild>
         <RouterLink :to="{ name: 'decks.clone', params: { deckId: deck.id } }">
           <IconCopy class="size-5 mr-4" />
@@ -113,6 +124,8 @@ import { reactive } from "vue";
 import { useRouter } from "vue-router";
 import EmbedDeckModal from "@/components/EmbedDeckModal.vue";
 import IconCopy from "@/components/icons/IconCopy.vue";
+import { CounterClockwiseClockIcon } from "@radix-icons/vue";
+import IconHistory from "@/components/icons/IconHistory.vue";
 
 defineProps<{
   deck: T.Deck;

--- a/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
+++ b/resources/client/pages/Decks/DeckIndexPage/MoreDeckActions.vue
@@ -124,7 +124,6 @@ import { reactive } from "vue";
 import { useRouter } from "vue-router";
 import EmbedDeckModal from "@/components/EmbedDeckModal.vue";
 import IconCopy from "@/components/icons/IconCopy.vue";
-import { CounterClockwiseClockIcon } from "@radix-icons/vue";
 import IconHistory from "@/components/icons/IconHistory.vue";
 
 defineProps<{

--- a/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
+++ b/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
@@ -34,6 +34,14 @@
             Report
           </RouterLink>
         </Button>
+        <Button asChild variant="secondary">
+          <RouterLink
+            v-if="deck.capabilities.canViewAuditHistory"
+            :to="{ name: 'decks.reports.auditHistory', params: { deckId } }"
+          >
+            History
+          </RouterLink>
+        </Button>
         <Button asChild>
           <RouterLink
             :to="{ name: 'decks.share', params: { deckId } }"

--- a/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
+++ b/resources/client/pages/Decks/DeckShowPage/DeckShowPage.vue
@@ -34,14 +34,6 @@
             Report
           </RouterLink>
         </Button>
-        <Button asChild variant="secondary">
-          <RouterLink
-            v-if="deck.capabilities.canViewAuditHistory"
-            :to="{ name: 'decks.reports.auditHistory', params: { deckId } }"
-          >
-            History
-          </RouterLink>
-        </Button>
         <Button asChild>
           <RouterLink
             :to="{ name: 'decks.share', params: { deckId } }"

--- a/resources/client/pages/Decks/DeckSummaryReportPage/DeckSummaryReportPage.vue
+++ b/resources/client/pages/Decks/DeckSummaryReportPage/DeckSummaryReportPage.vue
@@ -182,7 +182,6 @@ import { Badge } from "@/components/ui/badge";
 import { useDeckSummaryReportQuery } from "@/queries/decks/useDeckSummaryReportQuery";
 import DeckContextProvider from "@/components/DeckContextProvider.vue";
 import { RouterLink } from "vue-router";
-import { IconArrowRight } from "@/components/icons";
 import Button from "@/components/ui/button/Button.vue";
 
 const props = defineProps<{

--- a/resources/client/pages/Decks/DeckSummaryReportPage/DeckSummaryReportPage.vue
+++ b/resources/client/pages/Decks/DeckSummaryReportPage/DeckSummaryReportPage.vue
@@ -20,7 +20,9 @@
         </PageHeader>
 
         <div class="mb-8">
-          <h2 class="text-2xl font-bold mb-4">Cards</h2>
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-2xl font-bold">Cards</h2>
+          </div>
           <div>
             <Table>
               <TableHeader>
@@ -29,6 +31,8 @@
                   <TableHead class="text-center">Back</TableHead>
                   <TableHead class="text-center">Avg Score</TableHead>
                   <TableHead class="text-center">Attempts</TableHead>
+                  <TableHead class="text-center">Created</TableHead>
+                  <TableHead class="text-center">Edited</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -70,16 +74,49 @@
                     <span v-else class="text-sm text-brand-maroon-900/50">
                       -
                     </span>
-                    <!-- <Badge
-                    v-else
-                    variant="outline"
-                    class="text-sm bg-brand-maroon-900/5 text-brand-maroon-900/50"
-                  >
-                    N/A
-                  </Badge> -->
                   </TableCell>
                   <TableCell class="text-center">
                     {{ card.attempts_count }}
+                  </TableCell>
+                  <TableCell class="text-center">
+                    <div class="text-sm">
+                      <p class="font-medium">
+                        {{ formatDate(card.created_at) }}
+                      </p>
+                      <p class="text-brand-maroon-900/50">
+                        {{ card.created_by?.name ?? "-" }}
+                      </p>
+                    </div>
+                  </TableCell>
+                  <TableCell class="text-center">
+                    <div
+                      v-if="card.updated_at !== card.created_at"
+                      class="text-sm"
+                    >
+                      <p class="font-medium">
+                        {{ formatDate(card.updated_at) }}
+                      </p>
+                      <p class="text-brand-maroon-900/50">
+                        {{ card.updated_by?.name ?? "-" }}
+                      </p>
+                    </div>
+                    <p v-else class="text-sm text-brand-maroon-900/50">-</p>
+                  </TableCell>
+                  <TableCell class="text-center">
+                    <Button
+                      variant="secondary"
+                      asChild
+                      class="uppercase text-xs px-3 py-1.5"
+                    >
+                      <RouterLink
+                        :to="{
+                          name: 'cards.edit',
+                          params: { deckId, cardId: card.id },
+                        }"
+                      >
+                        Edit
+                      </RouterLink>
+                    </Button>
                   </TableCell>
                 </TableRow>
               </TableBody>
@@ -144,6 +181,9 @@ import MatchingSide from "@/pages/Activities/MatchingGamePage/MatchingSide.vue";
 import { Badge } from "@/components/ui/badge";
 import { useDeckSummaryReportQuery } from "@/queries/decks/useDeckSummaryReportQuery";
 import DeckContextProvider from "@/components/DeckContextProvider.vue";
+import { RouterLink } from "vue-router";
+import { IconArrowRight } from "@/components/icons";
+import Button from "@/components/ui/button/Button.vue";
 
 const props = defineProps<{
   deckId: number;
@@ -154,5 +194,15 @@ const { data: deck } = useDeckByIdQuery(deckIdRef);
 const { data: report } = useDeckSummaryReportQuery(deckIdRef);
 const memberships = computed(() => report.value?.memberships_with_stats ?? []);
 const cards = computed(() => report.value?.cards_with_stats ?? []);
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 </script>
 <style scoped></style>

--- a/resources/client/queries/decks/useDeckAuditHistoryQuery.ts
+++ b/resources/client/queries/decks/useDeckAuditHistoryQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/vue-query";
+import * as api from "@/api";
+import type { Ref } from "vue";
+import { DECKS_QUERY_KEY, REPORTS_QUERY_KEY } from "../queryKeys";
+
+export function useDeckAuditHistoryQuery(deckId: Ref<number>, page: Ref<number>) {
+  return useQuery({
+    queryKey: [DECKS_QUERY_KEY, deckId, REPORTS_QUERY_KEY, "audit-history", page],
+    queryFn: () => api.getDeckAuditHistory(deckId.value, page.value),
+  });
+}

--- a/resources/client/queries/decks/useDeckAuditHistoryQuery.ts
+++ b/resources/client/queries/decks/useDeckAuditHistoryQuery.ts
@@ -1,11 +1,15 @@
 import { useQuery } from "@tanstack/vue-query";
 import * as api from "@/api";
-import type { Ref } from "vue";
+import type { AuditHistoryParams } from "@/api";
+import type { ComputedRef } from "vue";
 import { DECKS_QUERY_KEY, REPORTS_QUERY_KEY } from "../queryKeys";
 
-export function useDeckAuditHistoryQuery(deckId: Ref<number>, page: Ref<number>) {
+export function useDeckAuditHistoryQuery(
+  deckId: ComputedRef<number>,
+  params: ComputedRef<AuditHistoryParams>,
+) {
   return useQuery({
-    queryKey: [DECKS_QUERY_KEY, deckId, REPORTS_QUERY_KEY, "audit-history", page],
-    queryFn: () => api.getDeckAuditHistory(deckId.value, page.value),
+    queryKey: [DECKS_QUERY_KEY, deckId, REPORTS_QUERY_KEY, "audit-history", params],
+    queryFn: () => api.getDeckAuditHistory(deckId.value, params.value),
   });
 }

--- a/resources/client/router/index.ts
+++ b/resources/client/router/index.ts
@@ -89,6 +89,17 @@ const router = createRouter({
       }),
     },
     {
+      path: "/decks/:deckId/reports/audit-history",
+      name: "decks.reports.auditHistory",
+      component: () =>
+        import(
+          "../pages/Decks/DeckAuditHistoryPage/DeckAuditHistoryPage.vue"
+        ),
+      props: (route) => ({
+        deckId: Number(route.params.deckId),
+      }),
+    },
+    {
       path: "/decks/:deckId/assignments",
       name: "decks.assignments",
       component: () =>

--- a/resources/client/types/index.ts
+++ b/resources/client/types/index.ts
@@ -105,6 +105,7 @@ export interface Deck {
     canLeave: boolean;
     canJoinAsViewer: boolean; // can join if not already a member, and deck is public
     canViewReports: boolean;
+    canViewAuditHistory: boolean;
     canViewGrades: boolean;
     canCreateCards: boolean;
   };
@@ -357,4 +358,40 @@ export interface AssignmentScore {
   submitted_at: ISODateTime | null;
   submission_success: boolean | null;
   submission_error: string | null;
+}
+
+// Audit History Types
+export type AuditEvent = "created" | "updated" | "deleted" | "restored";
+
+export type AuditableType = "Deck" | "Card";
+
+export interface AuditUser {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface AuditRecord {
+  id: number;
+  event: AuditEvent;
+  auditable_type: AuditableType;
+  auditable_id: number;
+  old_values: Record<string, unknown> | null;
+  new_values: Record<string, unknown> | null;
+  user: AuditUser | null;
+  created_at: ISODateTime;
+}
+
+export interface DeckAuditHistoryResponse {
+  data: AuditRecord[];
+  meta: {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+  };
+  links: {
+    prev: string | null;
+    next: string | null;
+  };
 }

--- a/resources/client/types/index.ts
+++ b/resources/client/types/index.ts
@@ -269,9 +269,16 @@ interface MemberParticipationStats {
   has_matching_activity: boolean;
 }
 
+interface CardAuditUser {
+  id: number;
+  name: string;
+}
+
 interface CardWithGlobalStats extends Card {
   attempts_count: number;
   attempts_avg_score: number;
+  created_by: CardAuditUser | null;
+  updated_by: CardAuditUser | null;
 }
 
 export interface DeckSummaryReport {

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\DeckController;
 use App\Http\Controllers\DeckInviteController;
 use App\Http\Controllers\DeckMembershipController;
 use App\Http\Controllers\DeckQuizController;
+use App\Http\Controllers\DeckAuditController;
 use App\Http\Controllers\DeckReportController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TTSController;
@@ -60,6 +61,8 @@ Route::middleware(['auth'])
         ]);
 
         Route::get('decks/{deck}/reports/summary', [DeckReportController::class, 'summary']);
+
+        Route::get('decks/{deck}/reports/audit-history', [DeckAuditController::class, 'index']);
 
         Route::get('decks/{deck}/assignments', [DeckAssignmentController::class, 'index']);
 

--- a/tests/Feature/DeckAuditControllerTest.php
+++ b/tests/Feature/DeckAuditControllerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Models\Card;
+use App\Models\Deck;
+use App\Models\DeckMembership;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->deck = Deck::factory()->create(['name' => 'Test Deck']);
+    DeckMembership::create([
+        'deck_id' => $this->deck->id,
+        'user_id' => $this->owner->id,
+        'role' => 'owner',
+    ]);
+});
+
+test('deck owner can view audit history', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history");
+
+    $response->assertSuccessful();
+    $response->assertJsonStructure([
+        'data',
+        'meta' => ['current_page', 'last_page', 'per_page', 'total'],
+        'links' => ['prev', 'next'],
+    ]);
+});
+
+test('non-owner cannot view audit history', function () {
+    $otherUser = User::factory()->create();
+
+    $response = $this->actingAs($otherUser)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history");
+
+    $response->assertForbidden();
+});
+
+test('unauthenticated user cannot view audit history', function () {
+    $response = $this->getJson("/api/decks/{$this->deck->id}/reports/audit-history");
+
+    $response->assertUnauthorized();
+});
+
+test('validates object parameter must be Deck or Card', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?object=InvalidType");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['object']);
+});
+
+test('validates action parameter must be a valid event type', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?action=invalid");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('validates id parameter must be a positive integer', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?id=-1");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['id']);
+});
+
+test('validates from parameter must be a valid date', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?from=not-a-date");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['from']);
+});
+
+test('validates to parameter must be after or equal to from', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?from=2025-01-15&to=2025-01-10");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['to']);
+});
+
+test('validates sort parameter must be a valid field', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?sort=invalid_field");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['sort']);
+});
+
+test('validates direction parameter must be asc or desc', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?direction=invalid");
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['direction']);
+});
+
+test('accepts valid filter parameters', function () {
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?".http_build_query([
+            'object' => 'Card',
+            'action' => 'created',
+            'id' => 1,
+            'user' => 'test',
+            'from' => '2025-01-01',
+            'to' => '2025-12-31',
+            'sort' => 'created_at',
+            'direction' => 'desc',
+        ]));
+
+    $response->assertSuccessful();
+});
+
+test('filters by object type', function () {
+    Card::factory()->for($this->deck)->create();
+
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?object=Card");
+
+    $response->assertSuccessful();
+    $data = $response->json('data');
+
+    foreach ($data as $audit) {
+        expect($audit['auditable_type'])->toBe('Card');
+    }
+});
+
+test('filters by action type', function () {
+    Card::factory()->for($this->deck)->create();
+
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?action=created");
+
+    $response->assertSuccessful();
+    $data = $response->json('data');
+
+    foreach ($data as $audit) {
+        expect($audit['event'])->toBe('created');
+    }
+});
+
+test('filters by auditable id', function () {
+    $card = Card::factory()->for($this->deck)->create();
+
+    $response = $this->actingAs($this->owner)
+        ->getJson("/api/decks/{$this->deck->id}/reports/audit-history?id={$card->id}&object=Card");
+
+    $response->assertSuccessful();
+    $data = $response->json('data');
+
+    foreach ($data as $audit) {
+        expect($audit['auditable_id'])->toBe($card->id);
+    }
+});


### PR DESCRIPTION
- Surfaces audit information to owners on the `History` page. Page is filterable and sortable.
- Shows user who created and user who last edited a card (along with the datetime) on the `Report` Page.

On dev

https://github.com/user-attachments/assets/b03afd2a-9ee1-4155-bfb2-f72a98cd476e


