### PR TITLE
fix: handle occasional `null` deck in `removeSelf` capabilities check

### DIFF
--- a/app/Policies/DeckMembershipPolicy.php
+++ b/app/Policies/DeckMembershipPolicy.php
@@ -75,7 +75,7 @@ class DeckMembershipPolicy
         // deleted before we check membership.
         // https://university-of-minnesota-rd.sentry.io/issues/7243453987
         if (! $deck) {
-            return false;
+            return true;
         }
 
         if (! $user->isOwnerOfDeck($deck)) {

--- a/app/Policies/DeckMembershipPolicy.php
+++ b/app/Policies/DeckMembershipPolicy.php
@@ -75,7 +75,7 @@ class DeckMembershipPolicy
         // deleted before we check membership.
         // https://university-of-minnesota-rd.sentry.io/issues/7243453987
         if (! $deck) {
-            return true;
+            return false;
         }
 
         if (! $user->isOwnerOfDeck($deck)) {

--- a/app/Policies/DeckMembershipPolicy.php
+++ b/app/Policies/DeckMembershipPolicy.php
@@ -70,6 +70,14 @@ class DeckMembershipPolicy
     public function removeSelf(User $user, DeckMembership $deckMembership): bool
     {
         $deck = $deckMembership->deck;
+
+        // Handle a race where deck could be null if it's soft
+        // deleted before we check membership.
+        // https://university-of-minnesota-rd.sentry.io/issues/7243453987
+        if (! $deck) {
+            return true;
+        }
+
         if (! $user->isOwnerOfDeck($deck)) {
             return true;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,6 +224,7 @@
       "integrity": "sha512-hXM2LpwTzG5kGQSyq3feIijzzl6vkjYPP+LF3ru1relNUIh7fWJ4uYQay2NMNbWX5LWQzF8Vr9qlIA139doQXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.20.4",
         "@algolia/requester-browser-xhr": "5.20.4",
@@ -2203,6 +2204,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2965,6 +2967,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3019,6 +3022,7 @@
       "integrity": "sha512-wjfzqruxovJyDqga8M6Xk5XtfuVg3igrWjhjgkRya87+WwfEa1kg+IluujBLzgAiMSd6rO6jqRb7czjgeeSYgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.20.4",
         "@algolia/client-analytics": "5.20.4",
@@ -3300,6 +3304,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3441,6 +3446,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4383,6 +4389,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -4518,6 +4525,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4978,7 +4986,8 @@
       "version": "4.32.11",
       "resolved": "https://registry.npmjs.org/filepond/-/filepond-4.32.11.tgz",
       "integrity": "sha512-+uHkc/XNksMMy2S+x5MGxTuA97NqzBBwmoixn3tqGELa4BgqJ+PBiWL3YeRamqAoYguT7t/au3s7ams2jjMshA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/filepond-plugin-file-validate-type": {
       "version": "1.2.9",
@@ -5073,6 +5082,7 @@
       "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -5969,6 +5979,7 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -6327,6 +6338,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7249,6 +7261,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7526,6 +7539,7 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -8468,6 +8482,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8597,6 +8612,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9286,6 +9302,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9530,6 +9547,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9634,6 +9652,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10195,6 +10214,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",


### PR DESCRIPTION
Resolves #172 

I think the trigger is a race between soft deleting and capabilities check:

1. User1 - makes an `api/decks` request.
2. User1 - `DeckController::index()` queries the DB for all the decks User1 is a member of.
3. User2 - soft deletes deck X in which User1 is a member.
4. User1 - `DeckController::index()` passes results to `DeckResource`, which appends `capabilities` data for all of User1's deck, including soft deleted Deck X. Capabilities checks the policy for `removeSelf` on `$deckMembership->deck`, which is now null and thus throws and exception.

There's probably better solutions, but this should be a quick fix that keeps `isOwnerOfDeck()` from encountering a null value.