### PR TITLE
fix(MathBlock): disable mathlive sounds

### DIFF
--- a/resources/client/app.ts
+++ b/resources/client/app.ts
@@ -13,6 +13,10 @@ import * as katex from "katex";
 window.katex = katex;
 import "katex/contrib/mhchem/mhchem.js";
 
+// disable attempts to play sounds
+import { MathfieldElement } from "mathlive";
+MathfieldElement.soundsDirectory = null;
+
 // for accessibility
 import VueAnnouncer from "@vue-a11y/announcer";
 

--- a/resources/client/app.ts
+++ b/resources/client/app.ts
@@ -2,8 +2,6 @@ import "@fontsource-variable/nunito/index.css";
 import "@fontsource-variable/rokkitt/index.css";
 
 import "./app.css";
-import "mathlive";
-
 import "katex/dist/katex.css";
 
 import { createApp } from "vue";


### PR DESCRIPTION
<img width="800"  alt="CleanShot 2026-05-20 at 21 27 29@2x" src="https://github.com/user-attachments/assets/efd5ecee-b5eb-4d68-87e9-15bf2836f58f" />

By default, mathlive wants to play a "plonk" sound whenever there's an error, like backspacing on an empty field (see above).

This disables sound.  Math doesn't need a pit orchestra.