### PR TITLE
 fix(Nova): handle soft-deleted user/deck in DeckMembership title

### DIFF
--- a/app/Nova/DeckMembership.php
+++ b/app/Nova/DeckMembership.php
@@ -3,11 +3,9 @@
 namespace App\Nova;
 
 use App\Models\DeckMembership as DeckMembershipModel;
-use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class DeckMembership extends Resource

--- a/app/Nova/DeckMembership.php
+++ b/app/Nova/DeckMembership.php
@@ -33,7 +33,12 @@ class DeckMembership extends Resource
      */
     public function title()
     {
-        return "{$this->user->name} ({$this->role}) - {$this->deck->name}";
+        // user/deck can be null when the related record is soft-deleted;
+        // fall back to the foreign key so the row stays identifiable.
+        $user = $this->user?->name ?? "User #{$this->user_id}";
+        $deck = $this->deck?->name ?? "Deck #{$this->deck_id}";
+
+        return "{$user} ({$this->role}) - {$deck}";
     }
 
     /**


### PR DESCRIPTION
fixes issue when viewing Deck index page in nova and the deck or user is soft-deleted. (sentry issue `SMARTYCARDS-1K: Attempt to read property "name" on null`). Will use FK user_id or deck_id as fallback.
